### PR TITLE
Fix stdout buffer overflow when more than 1 MB of docs are generated

### DIFF
--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -241,7 +241,10 @@ module.exports = (context, options) => ({
           `"${binaryPath}" extract "${root.replace(
             /\\/g,
             "/"
-          )}" --base "${basePath}"`
+          )}" --base "${basePath}"`,
+          {
+            maxBuffer: 10 * 1024 * 1024
+          }
         )
           .then(({ stdout, stderr }) => {
             if (stderr.length > 0) {


### PR DESCRIPTION
This moves the line to 10 MB instead.