### PR TITLE
Use stacker full_moon feature to mitigate stack overflow issues

### DIFF
--- a/extractor/Cargo.lock
+++ b/extractor/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,7 @@ dependencies = [
  "paste",
  "serde",
  "smol_str",
+ "stacker",
 ]
 
 [[package]]
@@ -315,6 +322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +419,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
 ]
 
 [[package]]

--- a/extractor/Cargo.toml
+++ b/extractor/Cargo.toml
@@ -22,7 +22,7 @@ opt-level = 1
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-full_moon = { git = "https://github.com/Kampfkarren/full-moon.git", rev = "5a8262720399c6540ade4210c4735d40b2e2df15" } # Specify commit fixing newlines until new release is cut
+full_moon = { features = ["stacker"], git = "https://github.com/Kampfkarren/full-moon.git", rev = "5a8262720399c6540ade4210c4735d40b2e2df15" } # Specify commit fixing newlines until new release is cut
 walkdir = "2"
 anyhow = "1.0.28"
 codespan-reporting = "0.9.5"


### PR DESCRIPTION
Running `moonwave dev` sometimes throws arbitrary stack overflow errors. Upon further investigation they come from full_moon.