### PR TITLE
Fix search links being incorrect

### DIFF
--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -27,17 +27,23 @@ export default async function buildCommand(args: Args) {
     const buildDir = path.join(projectDir, buildDirName)
 
     const command = "npm" + (process.platform === "win32" ? ".cmd" : "")
-    // TypeScript complains "Type 'string' is not assignable to type 'StdioOptions | undefined'" when passing spawnOptions to spawn(),
-    // if we do not make the spawnOptions variable have the type child_process.SpawnOptions
     const spawnOptions: SpawnOptions = {
-        cwd: tempDir,
-        stdio: "inherit",
+      cwd: tempDir,
+      stdio: "inherit",
     }
-  
+
     const swizzleExitCode = await new Promise((resolve) => {
       spawn(
         command,
-        ["run", "swizzle", "docusaurus-lunr-search", "SearchBar", "--", "--eject", "--danger"],
+        [
+          "run",
+          "swizzle",
+          "docusaurus-lunr-search",
+          "SearchBar",
+          "--",
+          "--eject",
+          "--danger",
+        ],
         spawnOptions
       )
         .on("exit", resolve)
@@ -47,7 +53,7 @@ export default async function buildCommand(args: Args) {
     if (swizzleExitCode !== 0) {
       throw new Error("Swizzle had an non-zero exit code")
     }
-  
+
     const exitCode = await new Promise((resolve) => {
       spawn(
         command,

--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process"
+import { SpawnOptions, spawn } from "child_process"
 import githubPages from "gh-pages"
 import path from "path"
 import { Args } from "../argv.js"
@@ -26,21 +26,40 @@ export default async function buildCommand(args: Args) {
     const buildDirName = args["out-dir"] || "build"
     const buildDir = path.join(projectDir, buildDirName)
 
+    const command = "npm" + (process.platform === "win32" ? ".cmd" : "")
+    // TypeScript complains "Type 'string' is not assignable to type 'StdioOptions | undefined'" when passing spawnOptions to spawn(),
+    // if we do not make the spawnOptions variable have the type child_process.SpawnOptions
+    const spawnOptions: SpawnOptions = {
+        cwd: tempDir,
+        stdio: "inherit",
+    }
+  
+    const swizzleExitCode = await new Promise((resolve) => {
+      spawn(
+        command,
+        ["run", "swizzle", "docusaurus-lunr-search", "SearchBar", "--", "--eject", "--danger"],
+        spawnOptions
+      )
+        .on("exit", resolve)
+        .on("error", console.error)
+    })
+
+    if (swizzleExitCode !== 0) {
+      throw new Error("Swizzle had an non-zero exit code")
+    }
+  
     const exitCode = await new Promise((resolve) => {
       spawn(
-        "npm" + (process.platform === "win32" ? ".cmd" : ""),
+        command,
         ["run", "build", "--", "--out-dir", buildDir],
-        {
-          cwd: tempDir,
-          stdio: "inherit",
-        }
+        spawnOptions
       )
         .on("exit", resolve)
         .on("error", console.error)
     })
 
     if (exitCode !== 0) {
-      throw new Error("Non-zero exit code")
+      throw new Error("Build had an non-zero exit code")
     }
 
     console.log(


### PR DESCRIPTION
This fixes the link search takes you to when clicking a suggestion being incorrect. It is necessary to use the swizzle command as Moonwave modifies/has a copy of the docusaurus-lunr-search SearchBar component.