### PR TITLE
Expand IsPunc to catch cases where an identifier is a function or not…

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/LuaType.js
+++ b/docusaurus-plugin-moonwave/src/components/LuaType.js
@@ -4,7 +4,7 @@ import { TypeLinksContext } from "./LuaClass"
 import styles from "./styles.module.css"
 import { Op, PrOp } from "./Syntax"
 
-const isPunc = (char) => !!char.match(/[\{\}<>\-\|]/)
+const isPunc = (char) => !!char.match(/[\{\}<>\-\|&<>()\[\]]/)
 const isWhitespace = (char) => !!char.match(/\s/)
 const isAtom = (char) => !isWhitespace(char) && !isPunc(char)
 


### PR DESCRIPTION
… a base type

Here is the test case where it breaks:
"(callback:<T>(internal:(k:{string&number})->T)->string)->{string|number}"
Here is the original file tokenized as json (not seperated)
```json
[
    {
        "type": "tuple",
        "unseparatedTokens": [
            {
                "type": "identifier",
                "identifier": "callback"
            },
            {
                "type": "punc",
                "punc": "<"
            },
            {
                "type": "luaType",
                "luaType": "T"
            },
            {
                "type": "punc",
                "punc": ">"
            },
            {
                "type": "tuple",
                "unseparatedTokens": [
                    {
                        "type": "identifier",
                        "identifier": "internal:(k"
                    },
                    {
                        "type": "table",
                        "unseparatedTokens": [
                            {
                                "type": "luaType",
                                "luaType": "string&number"
                            }
                        ]
                    },
                    {
                        "type": "luaType",
                        "luaType": ")"
                    },
                    {
                        "type": "arrow"
                    },
                    {
                        "type": "luaType",
                        "luaType": "T"
                    }
                ]
            },
            {
                "type": "arrow"
            },
            {
                "type": "luaType",
                "luaType": "string"
            }
        ]
    },
    {
        "type": "arrow"
    },
    {
        "type": "table",
        "unseparatedTokens": [
            {
                "type": "luaType",
                "luaType": "string"
            },
            {
                "type": "union"
            },
            {
                "type": "luaType",
                "luaType": "number"
            }
        ]
    }
]
```
As you can see, `internal:(k` is generated as an identifer, when that cannot be the case.
Here's what it look likes with my fix:
```json
[
    {
        "type": "tuple",
        "unseparatedTokens": [
            {
                "type": "identifier",
                "identifier": "callback"
            },
            {
                "type": "punc",
                "punc": "<"
            },
            {
                "type": "luaType",
                "luaType": "T"
            },
            {
                "type": "punc",
                "punc": ">"
            },
            {
                "type": "tuple",
                "unseparatedTokens": [
                    {
                        "type": "identifier",
                        "identifier": "internal"
                    },
                    {
                        "type": "tuple",
                        "unseparatedTokens": [
                            {
                                "type": "identifier",
                                "identifier": "k"
                            },
                            {
                                "type": "table",
                                "unseparatedTokens": [
                                    {
                                        "type": "luaType",
                                        "luaType": "string"
                                    },
                                    {
                                        "type": "punc",
                                        "punc": "&"
                                    },
                                    {
                                        "type": "luaType",
                                        "luaType": "number"
                                    }
                                ]
                            }
                        ]
                    },
                    {
                        "type": "arrow"
                    },
                    {
                        "type": "luaType",
                        "luaType": "T"
                    }
                ]
            },
            {
                "type": "arrow"
            },
            {
                "type": "luaType",
                "luaType": "string"
            }
        ]
    },
    {
        "type": "arrow"
    },
    {
        "type": "table",
        "unseparatedTokens": [
            {
                "type": "luaType",
                "luaType": "string"
            },
            {
                "type": "union"
            },
            {
                "type": "luaType",
                "luaType": "number"
            }
        ]
    }
]
```
As you can see, that issue no longer occurs, and it also correctly picks up the intersection symbol.