### PR TITLE
Fix for Node Security Patch CVE-2024-27980

### DIFF
--- a/cli/src/commands/build.ts
+++ b/cli/src/commands/build.ts
@@ -29,6 +29,7 @@ export default async function buildCommand(args: Args) {
     const command = "npm" + (process.platform === "win32" ? ".cmd" : "")
     const spawnOptions: SpawnOptions = {
       cwd: tempDir,
+      shell: true,
       stdio: "inherit",
     }
 

--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -62,6 +62,7 @@ export default async function devCommand(args: Args) {
         ["run", "start"],
         {
           cwd: tempDir,
+          shell: true,
           stdio: "inherit",
         }
       )


### PR DESCRIPTION
Closes #140

In April, Node released a security patch labeled [CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2). This PR follows the instructions in the security release and fixes the relevant issue.