### PR TITLE
Made it possible to section tags in the API list

### DIFF
--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -32,7 +32,8 @@ export type ClassOrder = (
   | string
   | {
       section?: string
-      classes: string[]
+      classes?: string[]
+      tag?:     string
     }
 )[]
 

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -12,7 +12,7 @@ const breakCapitalWordsZeroWidth = (text) =>
 const getFunctionCallOperator = (type) =>
   type === "static" ? "." : type === "method" ? ":" : ""
 
-const mapLinks = (nameSet, items) =>
+const mapLinksByName = (nameSet, items) =>
   items.map((name) => {
     if (!nameSet.has(name)) {
       throw new Error(
@@ -49,7 +49,7 @@ function flattenTOC(toc) {
 }
 
 function parseSimpleClassOrder(content, classOrder, nameSet) {
-  const listedLinks = mapLinks(nameSet, classOrder)
+  const listedLinks = mapLinksByName(nameSet, classOrder)
 
   const unlistedLinks = content
     .map((luaClass) => luaClass.name)
@@ -64,22 +64,37 @@ function parseSimpleClassOrder(content, classOrder, nameSet) {
   return [...listedLinks, ...unlistedLinks]
 }
 
-function parseSectionalClassOrder(content, classOrder, nameSet) {
-  const listedNames = classOrder.flatMap((section) => section.classes)
+function parseSectionalClassOrder(content, classOrder, filteredContent) {
+  const nameSet = new Set()
+  filteredContent.forEach((luaClass) => nameSet.add(luaClass.name))
+
+  const listedNames = []
 
   const listedSidebar = []
   classOrder.forEach((element) => {
+    const namesWithTags = filteredContent
+      .filter((luaClass) => luaClass.tags ? luaClass.tags.includes(element.tag) : false)
+      .map((luaClass) => luaClass.name)
+    const namesIncludedInClasses = element.classes || []
+
+    const tagsItems = mapLinksByName(nameSet, namesWithTags)
+    const classesItems = mapLinksByName(nameSet, namesIncludedInClasses)
+
     if (element.section) {
       listedSidebar.push({
         type: "category",
         label: element.section,
         collapsible: true,
         collapsed: element.collapsed ?? true,
-        items: mapLinks(nameSet, element.classes),
+        items: [...classesItems, ...tagsItems],
       })
     } else {
-      listedSidebar.push(...mapLinks(nameSet, element.classes))
+      const toPush = [...classesItems, ...tagsItems]
+      listedSidebar.push(...toPush)
     }
+
+    const toPush = [...namesWithTags, ...namesIncludedInClasses]
+    listedNames.push(toPush)
   })
 
   const unlistedSidebar = content
@@ -95,7 +110,9 @@ function parseSectionalClassOrder(content, classOrder, nameSet) {
   return [...listedSidebar, ...unlistedSidebar]
 }
 
-function parseClassOrder(content, classOrder, nameSet) {
+function parseClassOrder(content, classOrder, filteredContent) {
+  const nameSet = new Set()
+  filteredContent.forEach((luaClass) => nameSet.add(luaClass.name))
   if (classOrder.length === 0) {
     return [...nameSet].sort().map((name) => ({
       type: "link",
@@ -109,7 +126,7 @@ function parseClassOrder(content, classOrder, nameSet) {
     return parseSimpleClassOrder(content, classOrder, nameSet)
   } else {
     // Handles cases where classOrder is assigned via TOML tables
-    return parseSectionalClassOrder(content, classOrder, nameSet)
+    return parseSectionalClassOrder(content, classOrder, filteredContent)
   }
 }
 
@@ -329,7 +346,7 @@ module.exports = (context, options) => ({
     const allLuaClassNamesOrdered = parseClassOrder(
       filteredContent,
       classOrder,
-      nameSet
+      filteredContent
     )
 
     const sidebarClassNames = await createData(

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -95,6 +95,10 @@ section = "Another section name"
 classes = ["Class3", "Class4"]
 
 [[classOrder]]
+section = "Tag Section"
+tag = "TagForClasses"
+
+[[classOrder]]
 # No section name will link classes at the root level of the sidebar
 classes = ["Class5", "Class6"]
 


### PR DESCRIPTION
Wanted to make it possible to tag classes and section them on tags.

Seems to work well. You can also combined it with the classes option if you want to include specific files. But don't know why you want that?