### PR TITLE
Fix API page crash with `classOrder` with empty `classes` table

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/Redirect.js
+++ b/docusaurus-plugin-moonwave/src/components/Redirect.js
@@ -2,23 +2,19 @@ import { Redirect as RouterRedirect } from "@docusaurus/router"
 import React from "react"
 
 export default function Redirect({ sidebarClassNames, pluginOptions }) {
-  if (sidebarClassNames.length > 0) {
-    for (let index = 0; index < sidebarClassNames.length; index++) {
-      const element = sidebarClassNames[index]
-      if (element.type == "category" && element.items.length === 0) {
-        continue
-      }
-
-      const firstLuaClassName = (
-        element.type === "link" ? element.label : element.items[0].label
-      ).replace(/[\u200B]/g, "") // Strip out any extraneous 0-width spaces
-
-      return (
-        <RouterRedirect
-          to={`${pluginOptions.baseUrl}api/${firstLuaClassName}`}
-        />
-      )
+  for (let index = 0; index < sidebarClassNames.length; index++) {
+    const element = sidebarClassNames[index]
+    if (element.type == "category" && element.items.length === 0) {
+      continue
     }
+
+    const firstLuaClassName = (
+      element.type === "link" ? element.label : element.items[0].label
+    ).replace(/[\u200B]/g, "") // Strip out any extraneous 0-width spaces
+
+    return (
+      <RouterRedirect to={`${pluginOptions.baseUrl}api/${firstLuaClassName}`} />
+    )
   }
 
   return <RouterRedirect to={`${pluginOptions.baseUrl}api/404`} />

--- a/docusaurus-plugin-moonwave/src/components/Redirect.js
+++ b/docusaurus-plugin-moonwave/src/components/Redirect.js
@@ -3,16 +3,23 @@ import React from "react"
 
 export default function Redirect({ sidebarClassNames, pluginOptions }) {
   if (sidebarClassNames.length > 0) {
-    const firstLuaClassName = (
-      sidebarClassNames[0].type === "link"
-        ? sidebarClassNames[0].label
-        : sidebarClassNames[0].items[0].label
-    ).replace(/[\u200B]/g, "") // Strip out any extraneous 0-width spaces
+    for (let index = 0; index < sidebarClassNames.length; index++) {
+      const element = sidebarClassNames[index]
+      if (element.type == "category" && element.items.length === 0) {
+        continue
+      }
 
-    return (
-      <RouterRedirect to={`${pluginOptions.baseUrl}api/${firstLuaClassName}`} />
-    )
-  } else {
-    return <RouterRedirect to={`${pluginOptions.baseUrl}api/404`} />
+      const firstLuaClassName = (
+        element.type === "link" ? element.label : element.items[0].label
+      ).replace(/[\u200B]/g, "") // Strip out any extraneous 0-width spaces
+
+      return (
+        <RouterRedirect
+          to={`${pluginOptions.baseUrl}api/${firstLuaClassName}`}
+        />
+      )
+    }
   }
+
+  return <RouterRedirect to={`${pluginOptions.baseUrl}api/404`} />
 }


### PR DESCRIPTION
Fixes #137

The API page would crash if the first ``[[classOrder]]`` entry had no entries in it's ``classes`` array.

This change makes it so we loop through all sidebar classes and categories, filtering out categories without any classes, and then using the next valid class as our redirect.