### PR TITLE
Support Anonymous Function Assignments

### DIFF
--- a/extractor/src/diagnostic.rs
+++ b/extractor/src/diagnostic.rs
@@ -7,10 +7,10 @@ use serde::Serialize;
 #[derive(Debug, Default, Serialize)]
 pub struct Diagnostic {
     pub text: String,
-    start: usize,
-    len: usize,
-    file_id: usize,
-    additional_diagnostics: Vec<Diagnostic>,
+    pub start: usize,
+    pub len: usize,
+    pub file_id: usize,
+    pub additional_diagnostics: Vec<Diagnostic>,
 }
 
 impl Diagnostic {

--- a/extractor/test-input/failing/anonymous_function_assignment.lua
+++ b/extractor/test-input/failing/anonymous_function_assignment.lua
@@ -1,0 +1,28 @@
+--- @class Class
+--- Multiple variables and expressions leads to undesired behavior
+
+local class = {}
+
+--- @within Class
+--- Multiple variables should fail
+class.foo, class.bar = function(x: number): number end, function(y: string): string end
+
+--- @within Class
+--- Multiple variables should fail
+local freeFunctionA, freeFunctionB = function(x: number): number end, function(y: string): string end
+
+--- @within Class
+--- Multiple variables should fail
+baz, qux = function(x: number): number end, function(y: string): string end
+
+--- @within Class
+--- Multiple variables should fail
+local a, b = function(x: number): number end, function(y: string): string end
+
+--- @within Class
+--- Multiple expressions should fail
+quux = function(x: number): number end, function(y: string): string end
+
+--- @within Class
+--- Multiple expressions should fail
+local fum = function(x: number): number end, function(y: string): string end

--- a/extractor/test-input/passing/anonymous_function_assignment.lua
+++ b/extractor/test-input/passing/anonymous_function_assignment.lua
@@ -1,0 +1,12 @@
+--- @class Class
+
+local class = {}
+
+--- @within Class
+class.foo = function(x: number): number end
+
+--- @within Class
+local freeFunction = function(x: number): number end
+
+--- @within Class
+bar = function(x: number): number end

--- a/extractor/tests/snapshots/test_inputs__failing__anonymous_function_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__anonymous_function_assignment.lua-stderr.snap
@@ -1,0 +1,59 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+error: Assignments cannot have more than one variable
+  ┌─ test-input/failing/anonymous_function_assignment.lua:6:1
+  │  
+6 │ ╭ --- @within Class
+7 │ │ --- Multiple variables should fail
+  │ ╰──────────────────────────────────^ Assignments cannot have more than one variable
+8 │   class.foo, class.bar = function(x: number): number end, function(y: string): string end
+  │              --------- Additional variable here
+
+error: Assignments cannot have more than one variable
+   ┌─ test-input/failing/anonymous_function_assignment.lua:10:1
+   │  
+10 │ ╭ --- @within Class
+11 │ │ --- Multiple variables should fail
+   │ ╰──────────────────────────────────^ Assignments cannot have more than one variable
+12 │   local freeFunctionA, freeFunctionB = function(x: number): number end, function(y: string): string end
+   │                        ------------- Additional variable here
+
+error: Assignments cannot have more than one variable
+   ┌─ test-input/failing/anonymous_function_assignment.lua:14:1
+   │  
+14 │ ╭ --- @within Class
+15 │ │ --- Multiple variables should fail
+   │ ╰──────────────────────────────────^ Assignments cannot have more than one variable
+16 │   baz, qux = function(x: number): number end, function(y: string): string end
+   │        --- Additional variable here
+
+error: Assignments cannot have more than one variable
+   ┌─ test-input/failing/anonymous_function_assignment.lua:18:1
+   │  
+18 │ ╭ --- @within Class
+19 │ │ --- Multiple variables should fail
+   │ ╰──────────────────────────────────^ Assignments cannot have more than one variable
+20 │   local a, b = function(x: number): number end, function(y: string): string end
+   │            - Additional variable here
+
+error: Assignments cannot have more than one expression
+   ┌─ test-input/failing/anonymous_function_assignment.lua:22:1
+   │  
+22 │ ╭ --- @within Class
+23 │ │ --- Multiple expressions should fail
+   │ ╰────────────────────────────────────^ Assignments cannot have more than one expression
+24 │   quux = function(x: number): number end, function(y: string): string end
+   │                                           ------------------------------- Additional expression here
+
+error: Assignments cannot have more than one expression
+   ┌─ test-input/failing/anonymous_function_assignment.lua:26:1
+   │  
+26 │ ╭ --- @within Class
+27 │ │ --- Multiple expressions should fail
+   │ ╰────────────────────────────────────^ Assignments cannot have more than one expression
+28 │   local fum = function(x: number): number end, function(y: string): string end
+   │                                                ------------------------------- Additional expression here
+
+error: aborting due to diagnostic error

--- a/extractor/tests/snapshots/test_inputs__failing__anonymous_function_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__anonymous_function_assignment.lua-stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__anonymous_function_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__anonymous_function_assignment.lua-stderr.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__anonymous_function_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__anonymous_function_assignment.lua-stdout.snap
@@ -1,0 +1,84 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+[
+  {
+    "functions": [
+      {
+        "name": "foo",
+        "desc": "",
+        "params": [
+          {
+            "name": "x",
+            "desc": "",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "",
+            "lua_type": "number "
+          }
+        ],
+        "function_type": "static",
+        "source": {
+          "line": 6,
+          "path": ""
+        }
+      },
+      {
+        "name": "freeFunction",
+        "desc": "",
+        "params": [
+          {
+            "name": "x",
+            "desc": "",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "",
+            "lua_type": "number "
+          }
+        ],
+        "function_type": "static",
+        "source": {
+          "line": 9,
+          "path": ""
+        }
+      },
+      {
+        "name": "bar",
+        "desc": "",
+        "params": [
+          {
+            "name": "x",
+            "desc": "",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "",
+            "lua_type": "number "
+          }
+        ],
+        "function_type": "static",
+        "source": {
+          "line": 12,
+          "path": ""
+        }
+      }
+    ],
+    "properties": [],
+    "types": [],
+    "name": "Class",
+    "desc": "",
+    "source": {
+      "line": 2,
+      "path": ""
+    }
+  }
+]

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -76,6 +76,16 @@ fn triple_dash_wrong_comment() -> anyhow::Result<()> {
 }
 
 #[test]
+fn anomymous_function_assignment() -> anyhow::Result<()> {
+    run_moonwave("passing/anonymous_function_assignment.lua", 0)
+}
+
+#[test]
+fn failing_anomymous_function_assignment() -> anyhow::Result<()> {
+    run_moonwave("failing/anonymous_function_assignment.lua", 1)
+}
+
+#[test]
 fn param_validation() -> anyhow::Result<()> {
     run_moonwave("failing/param_validation.lua", 1)
 }


### PR DESCRIPTION
Resolves #139 

Supports Anonymous Function Assignments, such as the following
```luau
--- @within Class
class.foo = function(x: number): number end

--- @within Class
local freeFunction = function(x: number): number end

--- @within Class
bar = function(x: number): number end
```

When multiple variables or expressions are present, the Extractor will output the following Diagnostic:
```ansi
error: Assignments cannot have more than one variable
  ┌─ test-input/failing/anonymous_function_assignment.lua:6:1
  │  
6 │ ╭ --- @within Class
7 │ │ --- Multiple variables should fail
  │ ╰──────────────────────────────────^ Assignments cannot have more than one variable
8 │   class.foo, class.bar = function(x: number): number end, function(y: string): string end
  │              --------- Additional variable here
```