### PR TITLE
Add GitHub Actions and custom dir sections to Publish doc page

### DIFF
--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -66,6 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish doc to GitHub Pages
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Publish
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -66,8 +66,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish doc to GitHub Pages
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - run: npm i -g moonwave@latest
       - name: Publish
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -13,6 +13,21 @@ If you are using git and Github pages, you can publish your doc website with one
 
 Otherwise, you can run `moonwave build`, and your built website will be in a folder called `build` in your project directory.
 
+## Using GitHub Actions
+
+When you publish your doc via GitHub Actions you might need to provide the author details and GitHub token.
+
+```yaml
+- name: Publish
+    run: |
+    git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+    git config --global user.email "your@email.com"
+    git config --global user.name "Your Name"
+    moonwave build --publish
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 :::caution
 Remember to add the `build` folder to your `.gitignore`!
 :::
@@ -47,3 +62,11 @@ Even if you are using Github Pages, and:
 ## Github Pages Custom Domain CNAME file
 
 Github Pages requires you to create a CNAME file in your website to host on a custom domain. You should create this file at `yourProjectRoot/.moonwave/static/CNAME` (create the folders if they don't exist) and put your domain in the file. 
+
+## Custom build directory
+
+You can set a custom build folder instead the default `build` if needed by passing the `--out-dir` argument to `moonwave build` command.
+
+```sh
+moonwave --out-dir=custom_dir build
+```

--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -65,7 +65,7 @@ Github Pages requires you to create a CNAME file in your website to host on a cu
 
 ## Custom build directory
 
-You can set a custom build folder instead the default `build` if needed by passing the `--out-dir` argument to `moonwave build` command.
+You can set a custom build directory instead of the default `build` if needed by passing the `--out-dir` argument to `moonwave build` command.
 
 ```sh
 moonwave --out-dir=custom_dir build

--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -13,20 +13,7 @@ If you are using git and Github pages, you can publish your doc website with one
 
 Otherwise, you can run `moonwave build`, and your built website will be in a folder called `build` in your project directory.
 
-## Using GitHub Actions
-
-When you publish your doc via GitHub Actions you might need to provide the author details and GitHub token.
-
-```yaml
-- name: Publish
-    run: |
-    git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-    git config --global user.email "your@email.com"
-    git config --global user.name "Your Name"
-    moonwave build --publish
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+Or you can specify the `--out-dir [path]` argument to set the build directory to a different path.
 
 :::caution
 Remember to add the `build` folder to your `.gitignore`!
@@ -63,10 +50,28 @@ Even if you are using Github Pages, and:
 
 Github Pages requires you to create a CNAME file in your website to host on a custom domain. You should create this file at `yourProjectRoot/.moonwave/static/CNAME` (create the folders if they don't exist) and put your domain in the file. 
 
-## Custom build directory
+## Using GitHub Actions
 
-You can set a custom build directory instead of the default `build` if needed by passing the `--out-dir` argument to `moonwave build` command.
+You can create a GitHub Actions workflow to automatically publish your doc webiste to GitHub Pages. To begin, you need to create a new workflow in the `.github/workflows` directory of your repository that will build and publish your website.
 
-```sh
-moonwave --out-dir=custom_dir build
+Here is an example of such workflow where the job will run on each push to the `master` branch:
+
+```yaml
+# .github/workflows/publish.yml
+on:
+  push:
+    branches: ["master"]
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    name: Publish doc to GitHub Pages
+    steps:
+      - name: Publish
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git config --global user.email "support+actions@github.com"
+          git config --global user.name "github-actions-bot"
+          moonwave build --publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/website/docs/Publishing.md
+++ b/website/docs/Publishing.md
@@ -13,7 +13,7 @@ If you are using git and Github pages, you can publish your doc website with one
 
 Otherwise, you can run `moonwave build`, and your built website will be in a folder called `build` in your project directory.
 
-Or you can specify the `--out-dir [path]` argument to set the build directory to a different path.
+Additionally, you can also specify the `--out-dir [path]` argument to set the build directory to a different path other than the default `build` directory.
 
 :::caution
 Remember to add the `build` folder to your `.gitignore`!
@@ -52,24 +52,25 @@ Github Pages requires you to create a CNAME file in your website to host on a cu
 
 ## Using GitHub Actions
 
-You can create a GitHub Actions workflow to automatically publish your doc webiste to GitHub Pages. To begin, you need to create a new workflow in the `.github/workflows` directory of your repository that will build and publish your website.
+You can create a GitHub Actions workflow to automatically publish your docs webiste to GitHub Pages. To begin, you need to create a new workflow in the `.github/workflows` directory of your repository that will build and publish your website.
 
-Here is an example of such workflow where the job will run on each push to the `master` branch:
+Here is an example of such a workflow where the job will run on each push to the `master` branch:
 
 ```yaml
-# .github/workflows/publish.yml
+# .github/workflows/publish-docs.yml
+name: publish-docs
 on:
   push:
     branches: ["master"]
 jobs:
   status:
     runs-on: ubuntu-latest
-    name: Publish doc to GitHub Pages
+    name: Publish docs to GitHub Pages
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "22"
       - run: npm i -g moonwave@latest
       - name: Publish
         run: |


### PR DESCRIPTION
I guess it is a good idea to have these in the docs for future reference.