### PR TITLE
Infer from type statements

### DIFF
--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -71,7 +71,7 @@ struct DocEntryParseArguments<'a> {
     source: &'a DocComment,
 }
 
-fn get_within_tag<'a>(tags: &'a [Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
+fn get_within_tag(tags: & [Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
     for tag in tags {
         if let Tag::Within(within_tag) = tag {
             return Ok(within_tag.name.as_str().to_owned());

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -8,7 +8,12 @@ use crate::{
     tags::{validate_tags, Tag},
 };
 use full_moon::{
-    ast::{self, luau::{TypeDeclaration, TypeInfo}, punctuated::Punctuated, Stmt},
+    ast::{
+        self,
+        luau::{TypeDeclaration, TypeInfo},
+        punctuated::Punctuated,
+        Stmt,
+    },
     node::Node,
 };
 
@@ -152,7 +157,7 @@ where
 fn parse_type_declaration(
     declaration: &TypeDeclaration,
     doc_comment: &DocComment,
-    within_tag: Option<&crate::tags::WithinTag<'_>>
+    within_tag: Option<&crate::tags::WithinTag<'_>>,
 ) -> Result<DocEntryKind, Diagnostic> {
     let name = declaration.type_name().token().to_string();
 
@@ -476,7 +481,11 @@ impl<'a> DocEntry<'a> {
                 })?),
                 all_tags,
             ),
-            DocEntryKind::Type { within, name , type_info} => (
+            DocEntryKind::Type {
+                within,
+                name,
+                type_info,
+            } => (
                 DocEntry::Type(TypeDocEntry::parse(
                     DocEntryParseArguments {
                         within: Some(within),

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -154,7 +154,7 @@ fn parse_type_declaration(
     doc_comment: &DocComment,
     within_tag: Option<&crate::tags::WithinTag<'_>>
 ) -> Result<DocEntryKind, Diagnostic> {
-    let name = declaration.type_name().to_string();
+    let name = declaration.type_name().token().to_string();
 
     let within = if let Some(within) = within_tag {
         within.name.as_str().to_owned()

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -71,7 +71,7 @@ struct DocEntryParseArguments<'a> {
     source: &'a DocComment,
 }
 
-fn get_within_tag(tags: & [Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
+fn get_within_tag(tags: &[Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
     for tag in tags {
         if let Tag::Within(within_tag) = tag {
             return Ok(within_tag.name.as_str().to_owned());

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -47,16 +47,10 @@ fn gen_param_info_to_string(gen_param_info: &GenericParameterInfo) -> Option<Str
 }
 
 fn gen_decl_param_to_string(gen_decl_param: &GenericDeclarationParameter) -> Option<String> {
-    let parameter_string = match gen_param_info_to_string(gen_decl_param.parameter()) {
-        Some(string) => string,
-        None => return None,
-    };
+    let parameter_string = gen_param_info_to_string(gen_decl_param.parameter())?;
     let equals_string = optional_token_to_string(gen_decl_param.equals());
     let type_string = match gen_decl_param.default_type() {
-        Some(parameter) => match type_info_to_string(parameter) {
-            Some(string) => string,
-            None => return None,
-        },
+        Some(parameter) => type_info_to_string(parameter)?,
         None => String::new(),
     };
     Some(format!(
@@ -71,10 +65,7 @@ fn punctuated_generics_to_string(
     let mut string = String::new();
 
     for generic in punctuated {
-        let generic_string = match gen_decl_param_to_string(generic) {
-            Some(string) => string,
-            None => return None,
-        };
+        let generic_string = gen_decl_param_to_string(generic)?;
         string.push_str(generic_string.as_str())
     }
 
@@ -83,10 +74,7 @@ fn punctuated_generics_to_string(
 
 fn gen_decl_to_string(gen_decl: &GenericDeclaration) -> Option<String> {
     let (start, end) = gen_decl.arrows().tokens();
-    let generics_string = match punctuated_generics_to_string(gen_decl.generics()) {
-        Some(string) => string,
-        None => return None,
-    };
+    let generics_string = punctuated_generics_to_string(gen_decl.generics())?;
     Some(format!(
         "{}{}{}",
         start.token(),
@@ -99,10 +87,7 @@ fn punctuated_type_argument_to_string(punctuated: &Punctuated<TypeArgument>) -> 
     let mut string = String::new();
 
     for pair in punctuated.pairs() {
-        let type_string = match type_argument_to_string(pair.value()) {
-            Some(string) => string,
-            None => return None,
-        };
+        let type_string = type_argument_to_string(pair.value())?;
         string.push_str(type_string.as_str());
         string.push_str(optional_token_to_string(pair.punctuation()).as_str());
     }
@@ -114,10 +99,7 @@ fn punctuated_type_field_to_string(punctuated: &Punctuated<TypeField>) -> Option
     let mut string = String::new();
 
     for pair in punctuated.pairs() {
-        let type_string = match type_field_to_string(pair.value()) {
-            Some(string) => string,
-            None => return None,
-        };
+        let type_string = type_field_to_string(pair.value())?;
         string.push_str(type_string.as_str());
         string.push_str(optional_token_to_string(pair.punctuation()).as_str());
     }
@@ -129,10 +111,7 @@ fn punctuated_type_info_to_string(punctuated: &Punctuated<TypeInfo>) -> Option<S
     let mut string = String::new();
 
     for pair in punctuated.pairs() {
-        let type_string = match type_info_to_string(pair.value()) {
-            Some(string) => string,
-            None => return None,
-        };
+        let type_string = type_info_to_string(pair.value())?;
         string.push_str(type_string.as_str());
         string.push_str(optional_token_to_string(pair.punctuation()).as_str());
     }
@@ -150,10 +129,7 @@ fn indexed_type_info_to_string(indexed_type_info: &IndexedTypeInfo) -> Option<St
             generics,
         } => {
             let (start, end) = arrows.tokens();
-            let generics_string = match punctuated_type_info_to_string(generics) {
-                Some(string) => string,
-                None => return None,
-            };
+            let generics_string = punctuated_type_info_to_string(generics)?;
             Some(format!(
                 "{}{}{}{}",
                 base.token(),
@@ -182,24 +158,15 @@ fn type_argument_to_string(type_argument: &TypeArgument) -> Option<String> {
         }
         None => String::new(),
     };
-    let type_string = match type_info_to_string(type_argument.type_info()) {
-        Some(string) => string,
-        None => return None,
-    };
+    let type_string = type_info_to_string(type_argument.type_info())?;
     Some(format!("{}{}", name_string, type_string))
 }
 
 /// Converts a TypeField to a String representation, excluding trivia.
 fn type_field_to_string(type_field: &TypeField) -> Option<String> {
     let access = optional_token_to_string(type_field.access());
-    let key = match type_field_key_to_string(type_field.key()) {
-        Some(string) => string,
-        None => return None,
-    };
-    let value = match type_info_to_string(type_field.value()) {
-        Some(string) => string,
-        None => return None,
-    };
+    let key = type_field_key_to_string(type_field.key())?;
+    let value = type_info_to_string(type_field.value())?;
     Some(format!(
         "{}{}{}{}",
         access,
@@ -250,21 +217,12 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             return_type,
         } => {
             let generics_string = match generics {
-                Some(generics) => match gen_decl_to_string(generics) {
-                    Some(string) => string,
-                    None => return None,
-                },
+                Some(generics) => gen_decl_to_string(generics)?,
                 None => String::new(),
             };
             let (start, end) = parentheses.tokens();
-            let arguments_string = match punctuated_type_argument_to_string(arguments) {
-                Some(string) => string,
-                None => return None,
-            };
-            let return_type_string = match type_info_to_string(return_type) {
-                Some(string) => string,
-                None => return None,
-            };
+            let arguments_string = punctuated_type_argument_to_string(arguments)?;
+            let return_type_string = type_info_to_string(return_type)?;
             Some(format!(
                 "{}{}{}{}{}{}",
                 generics_string,
@@ -281,10 +239,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             generics,
         } => {
             let (start, end) = arrows.tokens();
-            let generics_string = match punctuated_type_info_to_string(generics) {
-                Some(string) => string,
-                None => return None,
-            };
+            let generics_string = punctuated_type_info_to_string(generics)?;
             Some(format!(
                 "{}{}{}{}",
                 base.token(),
@@ -298,10 +253,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
         }
         TypeInfo::Intersection(intersection) => {
             let leading_string = optional_token_to_string(intersection.leading());
-            let types_string = match punctuated_type_info_to_string(intersection.types()) {
-                Some(string) => string,
-                None => return None,
-            };
+            let types_string = punctuated_type_info_to_string(intersection.types())?;
             Some(format!("{}{}", leading_string, types_string))
         }
         TypeInfo::Module {
@@ -309,10 +261,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             punctuation,
             type_info,
         } => {
-            let module_index_string = match indexed_type_info_to_string(type_info.as_ref()) {
-                Some(string) => string,
-                None => return None,
-            };
+            let module_index_string = indexed_type_info_to_string(type_info.as_ref())?;
             Some(format!(
                 "{}{}{}",
                 module.token(),
@@ -324,18 +273,12 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             base,
             question_mark,
         } => {
-            let base_string = match type_info_to_string(base.as_ref()) {
-                Some(string) => string,
-                None => return None,
-            };
+            let base_string = type_info_to_string(base.as_ref())?;
             Some(format!("{}{}", base_string, question_mark.token()))
         }
         TypeInfo::Table { braces, fields } => {
             let (start, end) = braces.tokens();
-            let fields_string = match punctuated_type_field_to_string(fields) {
-                Some(string) => string,
-                None => return None,
-            };
+            let fields_string = punctuated_type_field_to_string(fields)?;
             Some(format!("{}{}{}", start.token(), fields_string, end.token()))
         }
         TypeInfo::Typeof {
@@ -348,34 +291,25 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 "{}{}{}{}",
                 typeof_token.token(),
                 start.token(),
-                inner.to_string(),
+                inner,
                 end.token()
             ))
         }
         TypeInfo::Tuple { parentheses, types } => {
             let (start, end) = parentheses.tokens();
-            let types_string = match punctuated_type_info_to_string(types) {
-                Some(string) => string,
-                None => return None,
-            };
+            let types_string = punctuated_type_info_to_string(types)?;
             Some(format!("{}{}{}", start.token(), types_string, end.token()))
         }
         TypeInfo::Union(union) => {
             let leading_string = optional_token_to_string(union.leading());
-            let types_string = match punctuated_type_info_to_string(union.types()) {
-                Some(string) => string,
-                None => return None,
-            };
+            let types_string = punctuated_type_info_to_string(union.types())?;
             Some(format!("{}{}", leading_string, types_string))
         }
         TypeInfo::Variadic {
             ellipsis,
             type_info,
         } => {
-            let type_string = match type_info_to_string(type_info.as_ref()) {
-                Some(string) => string,
-                None => return None,
-            };
+            let type_string = type_info_to_string(type_info.as_ref())?;
             Some(format!("{}{}", ellipsis.token(), type_string))
         }
         TypeInfo::VariadicPack { ellipsis, name } => {

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -87,9 +87,7 @@ impl<'a> TypeDocEntry<'a> {
         for tag in tags {
             match tag {
                 Tag::Type(type_tag) => {
-                    if let Some(explicit_lua_type) = type_tag.lua_type {
-                        doc_entry.lua_type = Some(explicit_lua_type.as_str().to_owned())
-                    }
+                    doc_entry.lua_type = Some(type_tag.lua_type.as_str().to_owned());
                 }
 
                 Tag::Field(field_tag) => doc_entry.fields.push(field_tag.into()),
@@ -104,10 +102,6 @@ impl<'a> TypeDocEntry<'a> {
             }
         }
 
-        if doc_entry.lua_type.is_none() && type_info.is_some() {
-            doc_entry.lua_type = Some(type_info.unwrap().to_string())
-        }
-
         if !unused_tags.is_empty() {
             let mut diagnostics = Vec::new();
             for tag in unused_tags {
@@ -115,6 +109,10 @@ impl<'a> TypeDocEntry<'a> {
             }
 
             return Err(Diagnostics::from(diagnostics));
+        }
+
+        if doc_entry.lua_type.is_none() {
+            doc_entry.lua_type = Some(type_info.unwrap().to_string());
         }
 
         Ok(doc_entry)

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -307,7 +307,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 "{}{}{}{}",
                 token_reference_to_string(typeof_token),
                 token_reference_to_string(start),
-                inner,
+                inner, // can contain comment trivia
                 token_reference_to_string(end)
             ))
         }

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -4,9 +4,17 @@ use crate::{
     serde_util::is_false,
     tags::{CustomTag, ExternalTag, FieldTag, Tag},
 };
-use full_moon::{ast::{luau::{
-    GenericDeclaration, GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo, TypeArgument, TypeField, TypeFieldKey, TypeInfo
-}, punctuated::Punctuated}, node::Node, tokenizer::{TokenReference, TokenType}};
+use full_moon::{
+    ast::{
+        luau::{
+            GenericDeclaration, GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo,
+            TypeArgument, TypeField, TypeFieldKey, TypeInfo,
+        },
+        punctuated::Punctuated,
+    },
+    node::Node,
+    tokenizer::{TokenReference, TokenType},
+};
 use serde::Serialize;
 
 use super::DocEntryParseArguments;
@@ -30,15 +38,9 @@ impl<'a> From<FieldTag<'a>> for Field {
 
 fn gen_param_info_to_string(gen_param_info: &GenericParameterInfo) -> Option<String> {
     match gen_param_info {
-        GenericParameterInfo::Name(name) => {
-            Some(name.token().to_string())
-        }
+        GenericParameterInfo::Name(name) => Some(name.token().to_string()),
         GenericParameterInfo::Variadic { name, ellipsis } => {
-            Some(format!(
-                "{}{}",
-                name.token(),
-                ellipsis.token()
-            ))
+            Some(format!("{}{}", name.token(), ellipsis.token()))
         }
         _ => None,
     }
@@ -46,7 +48,7 @@ fn gen_param_info_to_string(gen_param_info: &GenericParameterInfo) -> Option<Str
 
 fn gen_decl_param_to_string(gen_decl_param: &GenericDeclarationParameter) -> Option<String> {
     let parameter_string = match gen_param_info_to_string(gen_decl_param.parameter()) {
-        Some(string ) => string,
+        Some(string) => string,
         None => return None,
     };
     let equals_string = optional_token_to_string(gen_decl_param.equals());
@@ -59,13 +61,13 @@ fn gen_decl_param_to_string(gen_decl_param: &GenericDeclarationParameter) -> Opt
     };
     Some(format!(
         "{}{}{}",
-        parameter_string,
-        equals_string,
-        type_string
+        parameter_string, equals_string, type_string
     ))
 }
 
-fn punctuated_generics_to_string(punctuated: &Punctuated<GenericDeclarationParameter>) -> Option<String> {
+fn punctuated_generics_to_string(
+    punctuated: &Punctuated<GenericDeclarationParameter>,
+) -> Option<String> {
     let mut string = String::new();
 
     for generic in punctuated {
@@ -83,7 +85,7 @@ fn gen_decl_to_string(gen_decl: &GenericDeclaration) -> Option<String> {
     let (start, end) = gen_decl.arrows().tokens();
     let generics_string = match punctuated_generics_to_string(gen_decl.generics()) {
         Some(string) => string,
-        None => return None
+        None => return None,
     };
     Some(format!(
         "{}{}{}",
@@ -141,10 +143,12 @@ fn punctuated_type_info_to_string(punctuated: &Punctuated<TypeInfo>) -> Option<S
 /// Converts an IndexedTypeInfo to a String representation, excluding trivia.
 fn indexed_type_info_to_string(indexed_type_info: &IndexedTypeInfo) -> Option<String> {
     match indexed_type_info {
-        IndexedTypeInfo::Basic(basic) => {
-            Some(basic.token().to_string())
-        }
-        IndexedTypeInfo::Generic { base, arrows, generics } => {
+        IndexedTypeInfo::Basic(basic) => Some(basic.token().to_string()),
+        IndexedTypeInfo::Generic {
+            base,
+            arrows,
+            generics,
+        } => {
             let (start, end) = arrows.tokens();
             let generics_string = match punctuated_type_info_to_string(generics) {
                 Some(string) => string,
@@ -158,7 +162,7 @@ fn indexed_type_info_to_string(indexed_type_info: &IndexedTypeInfo) -> Option<St
                 end.token()
             ))
         }
-        _ => None
+        _ => None,
     }
 }
 
@@ -174,23 +178,15 @@ fn optional_token_to_string(token: Option<&TokenReference>) -> String {
 fn type_argument_to_string(type_argument: &TypeArgument) -> Option<String> {
     let name_string = match type_argument.name() {
         Some((identifier, colon)) => {
-            format!(
-                "{}{}",
-                identifier.token(),
-                colon.token()
-            )
-        },
+            format!("{}{}", identifier.token(), colon.token())
+        }
         None => String::new(),
     };
     let type_string = match type_info_to_string(type_argument.type_info()) {
         Some(string) => string,
         None => return None,
     };
-    Some(format!(
-        "{}{}",
-        name_string,
-        type_string
-    ))
+    Some(format!("{}{}", name_string, type_string))
 }
 
 /// Converts a TypeField to a String representation, excluding trivia.
@@ -220,17 +216,19 @@ fn type_field_key_to_string(field_key: &TypeFieldKey) -> Option<String> {
             let (start, end) = brackets.tokens();
             Some(format!("{}{}{}", start.token(), inner, end.token()))
         }
-        TypeFieldKey::Name(token_reference) => {
-            Some(token_reference.token().to_string())
-        }
-        _ => None
+        TypeFieldKey::Name(token_reference) => Some(token_reference.token().to_string()),
+        _ => None,
     }
 }
 
 /// Converts a TypeInfo to a String representation, excluding trivia.
 fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
     match type_info {
-        TypeInfo::Array { braces, access, type_info } => {
+        TypeInfo::Array {
+            braces,
+            access,
+            type_info,
+        } => {
             let (start, end) = braces.tokens();
             let access_string = optional_token_to_string(access.as_ref());
             Some(format!(
@@ -241,22 +239,20 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 end.token()
             ))
         }
-        TypeInfo::Basic(basic) => {
-            Some(basic.token().to_string())
-        }
-        TypeInfo::String(string) => {
-            Some(string.token().to_string())
-        }
-        TypeInfo::Boolean(boolean) => {
-            Some(boolean.token().to_string())
-        }
-        TypeInfo::Callback { generics, parentheses, arguments, arrow, return_type } => {
+        TypeInfo::Basic(basic) => Some(basic.token().to_string()),
+        TypeInfo::String(string) => Some(string.token().to_string()),
+        TypeInfo::Boolean(boolean) => Some(boolean.token().to_string()),
+        TypeInfo::Callback {
+            generics,
+            parentheses,
+            arguments,
+            arrow,
+            return_type,
+        } => {
             let generics_string = match generics {
-                Some(generics) => {
-                    match gen_decl_to_string(generics) {
-                        Some(string) => string,
-                        None => return None,
-                    }
+                Some(generics) => match gen_decl_to_string(generics) {
+                    Some(string) => string,
+                    None => return None,
                 },
                 None => String::new(),
             };
@@ -279,7 +275,11 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 return_type_string
             ))
         }
-        TypeInfo::Generic { base, arrows, generics } => {
+        TypeInfo::Generic {
+            base,
+            arrows,
+            generics,
+        } => {
             let (start, end) = arrows.tokens();
             let generics_string = match punctuated_type_info_to_string(generics) {
                 Some(string) => string,
@@ -294,11 +294,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             ))
         }
         TypeInfo::GenericPack { name, ellipsis } => {
-            Some(format!(
-                "{}{}",
-                name.token(),
-                ellipsis.token()
-            ))
+            Some(format!("{}{}", name.token(), ellipsis.token()))
         }
         TypeInfo::Intersection(intersection) => {
             let leading_string = optional_token_to_string(intersection.leading());
@@ -306,13 +302,13 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 Some(string) => string,
                 None => return None,
             };
-            Some(format!(
-                "{}{}",
-                leading_string,
-                types_string
-            ))
+            Some(format!("{}{}", leading_string, types_string))
         }
-        TypeInfo::Module { module, punctuation, type_info } => {
+        TypeInfo::Module {
+            module,
+            punctuation,
+            type_info,
+        } => {
             let module_index_string = match indexed_type_info_to_string(type_info.as_ref()) {
                 Some(string) => string,
                 None => return None,
@@ -324,16 +320,15 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 module_index_string
             ))
         }
-        TypeInfo::Optional { base, question_mark } => {
+        TypeInfo::Optional {
+            base,
+            question_mark,
+        } => {
             let base_string = match type_info_to_string(base.as_ref()) {
                 Some(string) => string,
-                None => return None
+                None => return None,
             };
-            Some(format!(
-                "{}{}",
-                base_string,
-                question_mark.token()
-            ))
+            Some(format!("{}{}", base_string, question_mark.token()))
         }
         TypeInfo::Table { braces, fields } => {
             let (start, end) = braces.tokens();
@@ -341,14 +336,13 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 Some(string) => string,
                 None => return None,
             };
-            Some(format!(
-                "{}{}{}",
-                start.token(),
-                fields_string,
-                end.token()
-            ))
+            Some(format!("{}{}{}", start.token(), fields_string, end.token()))
         }
-        TypeInfo::Typeof { typeof_token, parentheses, inner } => {
+        TypeInfo::Typeof {
+            typeof_token,
+            parentheses,
+            inner,
+        } => {
             let (start, end) = parentheses.tokens();
             Some(format!(
                 "{}{}{}{}",
@@ -364,12 +358,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 Some(string) => string,
                 None => return None,
             };
-            Some(format!(
-                "{}{}{}",
-                start.token(),
-                types_string,
-                end.token()
-            ))
+            Some(format!("{}{}{}", start.token(), types_string, end.token()))
         }
         TypeInfo::Union(union) => {
             let leading_string = optional_token_to_string(union.leading());
@@ -377,31 +366,22 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 Some(string) => string,
                 None => return None,
             };
-            Some(format!(
-                "{}{}",
-                leading_string,
-                types_string
-            ))
+            Some(format!("{}{}", leading_string, types_string))
         }
-        TypeInfo::Variadic { ellipsis, type_info } => {
+        TypeInfo::Variadic {
+            ellipsis,
+            type_info,
+        } => {
             let type_string = match type_info_to_string(type_info.as_ref()) {
                 Some(string) => string,
-                None => return None
+                None => return None,
             };
-            Some(format!(
-                "{}{}",
-                ellipsis.token(),
-                type_string
-            ))
+            Some(format!("{}{}", ellipsis.token(), type_string))
         }
         TypeInfo::VariadicPack { ellipsis, name } => {
-            Some(format!(
-                "{}{}",
-                ellipsis.token(),
-                name.token()
-            ))
+            Some(format!("{}{}", ellipsis.token(), name.token()))
         }
-        _ => None
+        _ => None,
     }
 }
 
@@ -467,21 +447,21 @@ impl<'a> TypeDocEntry<'a> {
                 TypeInfo::Table { fields, .. } => {
                     for pair in fields.pairs() {
                         let field = pair.value();
-                        
+
                         let name = match type_field_key_to_string(field.key()) {
                             Some(name) => name,
                             None => continue,
                         };
-                        
+
                         let lua_type = match type_info_to_string(field.value()) {
                             Some(lua_type) => lua_type,
-                            None => continue
+                            None => continue,
                         };
 
                         let punctuated_trivia = if let Some(punctuated) = pair.punctuation() {
                             vec![
                                 punctuated.leading_trivia().collect::<Vec<_>>(),
-                                punctuated.trailing_trivia().collect::<Vec<_>>()
+                                punctuated.trailing_trivia().collect::<Vec<_>>(),
                             ]
                             .into_iter()
                             .flatten()
@@ -498,18 +478,15 @@ impl<'a> TypeDocEntry<'a> {
                             .find_map(|token| match token.token_type() {
                                 TokenType::SingleLineComment { comment } => {
                                     if comment.starts_with("-") {
-                                        let string = comment
-                                            .strip_prefix("-")
-                                            .unwrap()
-                                            .trim()
-                                            .to_string();
+                                        let string =
+                                            comment.strip_prefix("-").unwrap().trim().to_string();
 
                                         Some(string)
                                     } else {
                                         None
                                     }
                                 }
-                                _ => None
+                                _ => None,
                             })
                             .unwrap_or_else(String::new);
 
@@ -519,10 +496,12 @@ impl<'a> TypeDocEntry<'a> {
                             desc,
                         });
                     }
-                },
-                _ => doc_entry.lua_type = match type_info_to_string(&type_info) {
-                    Some(string) => Some(string),
-                    None => Some(type_info.to_string().trim().to_string()),
+                }
+                _ => {
+                    doc_entry.lua_type = match type_info_to_string(&type_info) {
+                        Some(string) => Some(string),
+                        None => Some(type_info.to_string().trim().to_string()),
+                    }
                 }
             }
         }
@@ -537,9 +516,11 @@ impl<'a> TypeDocEntry<'a> {
 
                 Tag::Field(field_tag) => {
                     if type_info_exists {
-                        if let Some(found) = doc_entry.fields.iter_mut().find(|existing_field| {
-                            field_tag.name.as_str() == existing_field.name
-                        }) {
+                        if let Some(found) = doc_entry
+                            .fields
+                            .iter_mut()
+                            .find(|existing_field| field_tag.name.as_str() == existing_field.name)
+                        {
                             if !field_tag.lua_type.is_empty() {
                                 found.lua_type = field_tag.lua_type.to_string();
                             }
@@ -558,12 +539,14 @@ impl<'a> TypeDocEntry<'a> {
                         }
                     } else {
                         if field_tag.lua_type.is_empty() {
-                            field_tag.source.diagnostic("Field type is required when missing type info");
+                            field_tag
+                                .source
+                                .diagnostic("Field type is required when missing type info");
                         }
 
                         doc_entry.fields.push(field_tag.into())
                     }
-                },
+                }
 
                 Tag::Custom(custom_tag) => doc_entry.tags.push(custom_tag),
                 Tag::External(external_tag) => doc_entry.external_types.push(external_tag),

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -122,7 +122,7 @@ impl<'a> TypeDocEntry<'a> {
                         });
                     }
                 },
-                _ => doc_entry.lua_type = Some(type_info.to_string())
+                _ => doc_entry.lua_type = Some(type_info.to_string().trim().to_string())
             }
         }
 

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -206,7 +206,7 @@ fn type_field_key_to_string(field_key: &TypeFieldKey) -> Option<String> {
     match field_key {
         TypeFieldKey::IndexSignature { brackets, inner } => {
             let (start, end) = brackets.tokens();
-            Some(format!("{}{}{}", token_reference_to_string(start), inner, token_reference_to_string(end)))
+            Some(format!("{}{}{}", token_reference_to_string(start), type_info_to_string(inner)?, token_reference_to_string(end)))
         }
         TypeFieldKey::Name(token_reference) => Some(token_reference_to_string(token_reference)),
         _ => None,
@@ -226,7 +226,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
                 "{}{}{}{}",
                 token_reference_to_string(start),
                 optional_token_to_string(access.as_ref()),
-                type_info,
+                type_info_to_string(type_info)?,
                 token_reference_to_string(end)
             ))
         }

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -111,8 +111,19 @@ impl<'a> TypeDocEntry<'a> {
             return Err(Diagnostics::from(diagnostics));
         }
 
-        if doc_entry.lua_type.is_none() {
-            doc_entry.lua_type = Some(type_info.unwrap().to_string());
+        if let Some(type_info) = type_info {
+            match type_info {
+                TypeInfo::Table { fields, .. } => {
+                    for field in fields {
+                        doc_entry.fields.push(Field {
+                            name: field.key().to_string(),
+                            lua_type: field.value().to_string(),
+                            desc: String::new(),
+                        });
+                    }
+                },
+                _ => doc_entry.lua_type = Some(type_info.to_string())
+            }
         }
 
         Ok(doc_entry)

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -49,10 +49,7 @@ fn gen_decl_param_to_string(gen_decl_param: &GenericDeclarationParameter) -> Opt
         Some(string ) => string,
         None => return None,
     };
-    let equals_string = match gen_decl_param.equals() {
-        Some(equals) => equals.token().to_string(),
-        None => String::new(),
-    };
+    let equals_string = optional_token_to_string(gen_decl_param.equals());
     let type_string = match gen_decl_param.default_type() {
         Some(parameter) => match type_info_to_string(parameter) {
             Some(string) => string,
@@ -94,13 +91,6 @@ fn gen_decl_to_string(gen_decl: &GenericDeclaration) -> Option<String> {
         generics_string,
         end.token()
     ))
-}
-
-fn optional_token_to_string(token: Option<&TokenReference>) -> String {
-    match token {
-        Some(token) => token.token().to_string(),
-        None => String::new(),
-    }
 }
 
 fn punctuated_type_argument_to_string(punctuated: &Punctuated<TypeArgument>) -> Option<String> {
@@ -172,6 +162,14 @@ fn indexed_type_info_to_string(indexed_type_info: &IndexedTypeInfo) -> Option<St
     }
 }
 
+/// Converts an optional TokenReference to a String representation, excluding trivia.
+fn optional_token_to_string(token: Option<&TokenReference>) -> String {
+    match token {
+        Some(token) => token.token().to_string(),
+        None => String::new(),
+    }
+}
+
 /// Converts a TypeArgument to a String representation, excluding trivia.
 fn type_argument_to_string(type_argument: &TypeArgument) -> Option<String> {
     let name_string = match type_argument.name() {
@@ -197,10 +195,7 @@ fn type_argument_to_string(type_argument: &TypeArgument) -> Option<String> {
 
 /// Converts a TypeField to a String representation, excluding trivia.
 fn type_field_to_string(type_field: &TypeField) -> Option<String> {
-    let access = match type_field.access() {
-        Some(access) => access.token().to_string(),
-        None => String::new(),
-    };
+    let access = optional_token_to_string(type_field.access());
     let key = match type_field_key_to_string(type_field.key()) {
         Some(string) => string,
         None => return None,
@@ -237,10 +232,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
     match type_info {
         TypeInfo::Array { braces, access, type_info } => {
             let (start, end) = braces.tokens();
-            let access_string = match access {
-                Some(access) => access.token().to_string(),
-                None => String::new(),
-            };
+            let access_string = optional_token_to_string(access.as_ref());
             Some(format!(
                 "{}{}{}{}",
                 start.token(),
@@ -309,10 +301,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             ))
         }
         TypeInfo::Intersection(intersection) => {
-            let leading_string = match intersection.leading() {
-                Some(leading) => leading.token().to_string(),
-                None => String::new(),
-            };
+            let leading_string = optional_token_to_string(intersection.leading());
             let types_string = match punctuated_type_info_to_string(intersection.types()) {
                 Some(string) => string,
                 None => return None,
@@ -383,10 +372,7 @@ fn type_info_to_string(type_info: &TypeInfo) -> Option<String> {
             ))
         }
         TypeInfo::Union(union) => {
-            let leading_string = match union.leading() {
-                Some(leading) => leading.token().to_string(),
-                None => String::new(),
-            };
+            let leading_string = optional_token_to_string(union.leading());
             let types_string = match punctuated_type_info_to_string(union.types()) {
                 Some(string) => string,
                 None => return None,

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -41,10 +41,7 @@ fn token_reference_to_string(token_reference: &TokenReference) -> String {
 
     let leading = token_reference
         .leading_trivia()
-        .filter(|x| match x.token_kind() {
-            tokenizer::TokenKind::Whitespace => true,
-            _ => false,
-        })
+        .filter(|x| matches!(x.token_kind(), tokenizer::TokenKind::Whitespace))
         .map(|t| t.to_string())
         .collect::<String>();
 
@@ -54,10 +51,7 @@ fn token_reference_to_string(token_reference: &TokenReference) -> String {
 
     let trailing = token_reference
         .trailing_trivia()
-        .filter(|x| match x.token_kind() {
-            tokenizer::TokenKind::Whitespace => true,
-            _ => false,
-        })
+        .filter(|x| matches!(x.token_kind(), tokenizer::TokenKind::Whitespace))
         .map(|t| t.to_string())
         .collect::<String>();
 

--- a/extractor/src/doc_entry/type_definition.rs
+++ b/extractor/src/doc_entry/type_definition.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use full_moon::{ast::{luau::{
     GenericDeclaration, GenericDeclarationParameter, GenericParameterInfo, IndexedTypeInfo, TypeArgument, TypeField, TypeFieldKey, TypeInfo
-}, punctuated::{Punctuated}}, node::Node, tokenizer::{TokenReference, TokenType}};
+}, punctuated::Punctuated}, node::Node, tokenizer::{TokenReference, TokenType}};
 use serde::Serialize;
 
 use super::DocEntryParseArguments;

--- a/extractor/src/tags/field.rs
+++ b/extractor/src/tags/field.rs
@@ -30,7 +30,7 @@ impl<'a> FieldTag<'a> {
         let lua_type = pieces
             .next()
             .map(|name| name.trim())
-            .ok_or_else(|| span.diagnostic("Field type is required"))?;
+            .unwrap_or_else(|| Span::dummy(""));
 
         Ok(Self {
             name,

--- a/extractor/src/tags/type_tag.rs
+++ b/extractor/src/tags/type_tag.rs
@@ -5,7 +5,7 @@ use crate::{diagnostic::Diagnostic, span::Span};
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct TypeTag<'a> {
     pub name: Span<'a>,
-    pub lua_type: Span<'a>,
+    pub lua_type: Option<Span<'a>>,
     #[serde(skip)]
     pub source: Span<'a>,
 }
@@ -17,8 +17,7 @@ impl<'a> TypeTag<'a> {
 
         let lua_type = pieces
             .next()
-            .map(Span::trim)
-            .ok_or_else(|| span.diagnostic("Property type is required"))?;
+            .map(Span::trim);
 
         Ok(Self {
             name,

--- a/extractor/src/tags/type_tag.rs
+++ b/extractor/src/tags/type_tag.rs
@@ -5,7 +5,7 @@ use crate::{diagnostic::Diagnostic, span::Span};
 #[derive(Debug, PartialEq, Serialize, Clone)]
 pub struct TypeTag<'a> {
     pub name: Span<'a>,
-    pub lua_type: Option<Span<'a>>,
+    pub lua_type: Span<'a>,
     #[serde(skip)]
     pub source: Span<'a>,
 }
@@ -17,7 +17,8 @@ impl<'a> TypeTag<'a> {
 
         let lua_type = pieces
             .next()
-            .map(Span::trim);
+            .map(Span::trim)
+            .ok_or_else(|| span.diagnostic("Property type is required"))?;
 
         Ok(Self {
             name,

--- a/extractor/test-input/failing/missing_fields.lua
+++ b/extractor/test-input/failing/missing_fields.lua
@@ -1,0 +1,8 @@
+--- @class MissingFields
+--- Fail to add information for fields that do not exist.
+
+--- @within MissingFields
+--- @field reason -- Ratelimit or id not found.
+type petError = {
+	name: string
+}

--- a/extractor/test-input/failing/missing_fields.lua
+++ b/extractor/test-input/failing/missing_fields.lua
@@ -2,7 +2,7 @@
 --- Fail to add information for fields that do not exist.
 
 --- @within MissingFields
---- @field reason -- Ratelimit or id not found.
+--- @field HTTP -- True for database related errors.
 type petError = {
 	name: string
 }

--- a/extractor/test-input/passing/type_statement_inference.lua
+++ b/extractor/test-input/passing/type_statement_inference.lua
@@ -43,7 +43,19 @@ type randomLibrary = any
 --- @within TypeStatementInference
 --- Trivia is used to add field descriptions.
 type petStorage = {
-	entries: {petData} -- Maximum size of 100.
+	entries: {petData}, --- Maximum size of 100.
+
+	--- Current size of `entries`.
+	size: number,
+
+	lastAdded: number --- Unix timestamp.
+}
+
+--- @within TypeStatementInference
+--- Extra test for leading unpunctuated trivia.
+type petStorageUnreleased = {
+	--- Unix timestamp. Changes for insertions and deletions.
+	lastSizeChanged: number
 }
 
 --- @within TypeStatementInference
@@ -51,6 +63,6 @@ type petStorage = {
 --- @field set -- `id` must match `data.id`
 --- `@field` can overwrite information on existing fields.
 type petDatabase = {
-	get: (id: number) -> pet,
-	set: (id: number, data: petData) -> () -- This comment will be removed.
+	get: (id: number) -> pet, --- Cached in [petStorage].
+	set: (id: number, data: petData) -> () --- This comment will be removed.
 }

--- a/extractor/test-input/passing/type_statement_inference.lua
+++ b/extractor/test-input/passing/type_statement_inference.lua
@@ -2,7 +2,7 @@
 --- Infer types from type statements.
 
 --- @within TypeStatementInference
---- Table gets converted to interface.
+--- Tables get converted to interfaces.
 type baseData = {
 	id: number
 }
@@ -12,22 +12,45 @@ type baseData = {
 type pet = "cat" | "dog"
 
 --- @within TypeStatementInference
---- Unions and intersections are not marked as interfaces.
+--- Anything not strictly a table (union, intersection, et cetera) is not marked as an interface.
 type petData = baseData & {
 	pet: pet
 }
 
 --- @within TypeStatementInference
---- Exported types work the same.
+--- Exported types work the same as non exported.
 export type response = petData?
 
 --- @within TypeStatementInference
+--- Exported interfaces work the same as non exported.
+export type responseFull = {
+	method: "GET",
+	body: petData?
+}
+
+--- @within TypeStatementInference
 --- @type petFetcher (id: number) -> response
---- \@type can override.
+--- `@type` can override.
 type randomFetcher = any
 
 --- @within TypeStatementInference
 --- @interface petLibrary
 --- @field toPet (baseData) -> petData
---- \@interface can override.
+--- @field getDatabase () -> petDatabase
+--- `@interface` can override.
 type randomLibrary = any
+
+--- @within TypeStatementInference
+--- Trivia is used to add field descriptions.
+type petStorage = {
+	entries: {petData} -- Maximum size of 100.
+}
+
+--- @within TypeStatementInference
+--- @field get (id: number) -> responseFull
+--- @field set -- `id` must match `data.id`
+--- `@field` can overwrite information on existing fields.
+type petDatabase = {
+	get: (id: number) -> pet,
+	set: (id: number, data: petData) -> () -- This comment will be removed.
+}

--- a/extractor/test-input/passing/type_statement_inference.lua
+++ b/extractor/test-input/passing/type_statement_inference.lua
@@ -1,0 +1,33 @@
+--- @class TypeStatementInference
+--- Infer types from type statements.
+
+--- @within TypeStatementInference
+--- Table gets converted to interface.
+type baseData = {
+	id: number
+}
+
+--- @within TypeStatementInference
+--- Everything else uses a basic string representation.
+type pet = "cat" | "dog"
+
+--- @within TypeStatementInference
+--- Unions and intersections are not marked as interfaces.
+type petData = baseData & {
+	pet: pet
+}
+
+--- @within TypeStatementInference
+--- Exported types work the same.
+export type response = petData?
+
+--- @within TypeStatementInference
+--- @type petFetcher (id: number) -> response
+--- \@type can override.
+type randomFetcher = any
+
+--- @within TypeStatementInference
+--- @interface petLibrary
+--- @field toPet (baseData) -> petData
+--- \@interface can override.
+type randomLibrary = any

--- a/extractor/tests/snapshots/test_inputs__failing__missing_fields.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__missing_fields.lua-stderr.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+error: Field "HTTP" does not actually exist in interface
+  ┌─ test-input/failing/missing_fields.lua:5:12
+  │
+5 │ --- @field HTTP -- True for database related errors.
+  │            ^^^^ Field "HTTP" does not actually exist in interface
+
+error: aborting due to diagnostic error

--- a/extractor/tests/snapshots/test_inputs__failing__missing_fields.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__missing_fields.lua-stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stderr.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
@@ -9,7 +9,7 @@ expression: stdout
     "types": [
       {
         "name": "baseData",
-        "desc": "Tables get converted to interfaces.\r",
+        "desc": "Tables get converted to interfaces.",
         "fields": [
           {
             "name": "id",
@@ -24,7 +24,7 @@ expression: stdout
       },
       {
         "name": "pet",
-        "desc": "Everything else uses a basic string representation.\r",
+        "desc": "Everything else uses a basic string representation.",
         "lua_type": "\"cat\"|\"dog\"",
         "source": {
           "line": 12,
@@ -33,7 +33,7 @@ expression: stdout
       },
       {
         "name": "petData",
-        "desc": "Anything not strictly a table (union, intersection, et cetera) is not marked as an interface.\r",
+        "desc": "Anything not strictly a table (union, intersection, et cetera) is not marked as an interface.",
         "lua_type": "baseData&{pet:pet}",
         "source": {
           "line": 16,
@@ -42,7 +42,7 @@ expression: stdout
       },
       {
         "name": "response",
-        "desc": "Exported types work the same as non exported.\r",
+        "desc": "Exported types work the same as non exported.",
         "lua_type": "petData?",
         "source": {
           "line": 22,
@@ -51,7 +51,7 @@ expression: stdout
       },
       {
         "name": "responseFull",
-        "desc": "Exported interfaces work the same as non exported.\r",
+        "desc": "Exported interfaces work the same as non exported.",
         "fields": [
           {
             "name": "method",
@@ -71,7 +71,7 @@ expression: stdout
       },
       {
         "name": "petFetcher",
-        "desc": "`@type` can override.\r",
+        "desc": "`@type` can override.",
         "lua_type": "(id: number) -> response",
         "source": {
           "line": 34,
@@ -80,7 +80,7 @@ expression: stdout
       },
       {
         "name": "petLibrary",
-        "desc": "`@interface` can override.\r",
+        "desc": "`@interface` can override.",
         "fields": [
           {
             "name": "toPet",
@@ -100,7 +100,7 @@ expression: stdout
       },
       {
         "name": "petStorage",
-        "desc": "Trivia is used to add field descriptions.\r",
+        "desc": "Trivia is used to add field descriptions.",
         "fields": [
           {
             "name": "entries",
@@ -125,7 +125,7 @@ expression: stdout
       },
       {
         "name": "petStorageUnreleased",
-        "desc": "Extra test for leading unpunctuated trivia.\r",
+        "desc": "Extra test for leading unpunctuated trivia.",
         "fields": [
           {
             "name": "lastSizeChanged",
@@ -140,7 +140,7 @@ expression: stdout
       },
       {
         "name": "petDatabase",
-        "desc": "`@field` can overwrite information on existing fields.\r",
+        "desc": "`@field` can overwrite information on existing fields.",
         "fields": [
           {
             "name": "get",
@@ -160,7 +160,7 @@ expression: stdout
       }
     ],
     "name": "TypeStatementInference",
-    "desc": "Infer types from type statements.\r",
+    "desc": "Infer types from type statements.",
     "source": {
       "line": 3,
       "path": ""

--- a/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
@@ -12,8 +12,8 @@ expression: stdout
         "desc": "Tables get converted to interfaces.",
         "fields": [
           {
-            "name": "id",
-            "lua_type": "number",
+            "name": "\tid",
+            "lua_type": "number\n",
             "desc": ""
           }
         ],
@@ -25,7 +25,7 @@ expression: stdout
       {
         "name": "pet",
         "desc": "Everything else uses a basic string representation.",
-        "lua_type": "\"cat\"|\"dog\"",
+        "lua_type": "\"cat\" | \"dog\"\n",
         "source": {
           "line": 12,
           "path": ""
@@ -34,7 +34,7 @@ expression: stdout
       {
         "name": "petData",
         "desc": "Anything not strictly a table (union, intersection, et cetera) is not marked as an interface.",
-        "lua_type": "baseData&{pet:pet}",
+        "lua_type": "baseData & {\n\tpet: pet\n}\n",
         "source": {
           "line": 16,
           "path": ""
@@ -43,7 +43,7 @@ expression: stdout
       {
         "name": "response",
         "desc": "Exported types work the same as non exported.",
-        "lua_type": "petData?",
+        "lua_type": "petData?\n",
         "source": {
           "line": 22,
           "path": ""
@@ -54,13 +54,13 @@ expression: stdout
         "desc": "Exported interfaces work the same as non exported.",
         "fields": [
           {
-            "name": "method",
+            "name": "\tmethod",
             "lua_type": "\"GET\"",
             "desc": ""
           },
           {
-            "name": "body",
-            "lua_type": "petData?",
+            "name": "\tbody",
+            "lua_type": "petData?\n",
             "desc": ""
           }
         ],
@@ -103,18 +103,18 @@ expression: stdout
         "desc": "Trivia is used to add field descriptions.",
         "fields": [
           {
-            "name": "entries",
+            "name": "\tentries",
             "lua_type": "{petData}",
             "desc": "Maximum size of 100."
           },
           {
-            "name": "size",
+            "name": "\n\t\n\tsize",
             "lua_type": "number",
             "desc": "Current size of `entries`."
           },
           {
-            "name": "lastAdded",
-            "lua_type": "number",
+            "name": "\n\tlastAdded",
+            "lua_type": "number \n",
             "desc": "Unix timestamp."
           }
         ],
@@ -128,8 +128,8 @@ expression: stdout
         "desc": "Extra test for leading unpunctuated trivia.",
         "fields": [
           {
-            "name": "lastSizeChanged",
-            "lua_type": "number",
+            "name": "\t\n\tlastSizeChanged",
+            "lua_type": "number\n",
             "desc": "Unix timestamp. Changes for insertions and deletions."
           }
         ],
@@ -143,13 +143,13 @@ expression: stdout
         "desc": "`@field` can overwrite information on existing fields.",
         "fields": [
           {
-            "name": "get",
+            "name": "\tget",
             "lua_type": "(id: number) -> responseFull",
             "desc": "Cached in [petStorage]."
           },
           {
-            "name": "set",
-            "lua_type": "(id:number,data:petData)->()",
+            "name": "\tset",
+            "lua_type": "(id: number, data: petData) -> () \n",
             "desc": "`id` must match `data.id`"
           }
         ],

--- a/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
@@ -1,0 +1,84 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+[
+  {
+    "functions": [],
+    "properties": [],
+    "types": [
+      {
+        "name": "baseData ",
+        "desc": "Table gets converted to interface.\r",
+        "fields": [
+          {
+            "name": "\tid",
+            "lua_type": "number\r\n",
+            "desc": ""
+          }
+        ],
+        "source": {
+          "line": 6,
+          "path": ""
+        }
+      },
+      {
+        "name": "pet ",
+        "desc": "Everything else uses a basic string representation.\r",
+        "lua_type": "\"cat\" | \"dog\"\r\n",
+        "source": {
+          "line": 12,
+          "path": ""
+        }
+      },
+      {
+        "name": "petData ",
+        "desc": "Unions and intersections are not marked as interfaces.\r",
+        "lua_type": "baseData & {\r\n\tpet: pet\r\n}\r\n",
+        "source": {
+          "line": 16,
+          "path": ""
+        }
+      },
+      {
+        "name": "response ",
+        "desc": "Exported types work the same.\r",
+        "lua_type": "petData?\r\n",
+        "source": {
+          "line": 22,
+          "path": ""
+        }
+      },
+      {
+        "name": "petFetcher",
+        "desc": "\\@type can override.\r",
+        "lua_type": "(id: number) -> response",
+        "source": {
+          "line": 27,
+          "path": ""
+        }
+      },
+      {
+        "name": "petLibrary",
+        "desc": "\\@interface can override.\r",
+        "fields": [
+          {
+            "name": "toPet",
+            "lua_type": "(baseData) -> petData",
+            "desc": ""
+          }
+        ],
+        "source": {
+          "line": 33,
+          "path": ""
+        }
+      }
+    ],
+    "name": "TypeStatementInference",
+    "desc": "Infer types from type statements.\r",
+    "source": {
+      "line": 3,
+      "path": ""
+    }
+  }
+]

--- a/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__type_statement_inference.lua-stdout.snap
@@ -8,12 +8,12 @@ expression: stdout
     "properties": [],
     "types": [
       {
-        "name": "baseData ",
-        "desc": "Table gets converted to interface.\r",
+        "name": "baseData",
+        "desc": "Tables get converted to interfaces.\r",
         "fields": [
           {
-            "name": "\tid",
-            "lua_type": "number\r\n",
+            "name": "id",
+            "lua_type": "number",
             "desc": ""
           }
         ],
@@ -23,53 +23,138 @@ expression: stdout
         }
       },
       {
-        "name": "pet ",
+        "name": "pet",
         "desc": "Everything else uses a basic string representation.\r",
-        "lua_type": "\"cat\" | \"dog\"\r\n",
+        "lua_type": "\"cat\"|\"dog\"",
         "source": {
           "line": 12,
           "path": ""
         }
       },
       {
-        "name": "petData ",
-        "desc": "Unions and intersections are not marked as interfaces.\r",
-        "lua_type": "baseData & {\r\n\tpet: pet\r\n}\r\n",
+        "name": "petData",
+        "desc": "Anything not strictly a table (union, intersection, et cetera) is not marked as an interface.\r",
+        "lua_type": "baseData&{pet:pet}",
         "source": {
           "line": 16,
           "path": ""
         }
       },
       {
-        "name": "response ",
-        "desc": "Exported types work the same.\r",
-        "lua_type": "petData?\r\n",
+        "name": "response",
+        "desc": "Exported types work the same as non exported.\r",
+        "lua_type": "petData?",
         "source": {
           "line": 22,
           "path": ""
         }
       },
       {
+        "name": "responseFull",
+        "desc": "Exported interfaces work the same as non exported.\r",
+        "fields": [
+          {
+            "name": "method",
+            "lua_type": "\"GET\"",
+            "desc": ""
+          },
+          {
+            "name": "body",
+            "lua_type": "petData?",
+            "desc": ""
+          }
+        ],
+        "source": {
+          "line": 26,
+          "path": ""
+        }
+      },
+      {
         "name": "petFetcher",
-        "desc": "\\@type can override.\r",
+        "desc": "`@type` can override.\r",
         "lua_type": "(id: number) -> response",
         "source": {
-          "line": 27,
+          "line": 34,
           "path": ""
         }
       },
       {
         "name": "petLibrary",
-        "desc": "\\@interface can override.\r",
+        "desc": "`@interface` can override.\r",
         "fields": [
           {
             "name": "toPet",
             "lua_type": "(baseData) -> petData",
             "desc": ""
+          },
+          {
+            "name": "getDatabase",
+            "lua_type": "() -> petDatabase",
+            "desc": ""
           }
         ],
         "source": {
-          "line": 33,
+          "line": 41,
+          "path": ""
+        }
+      },
+      {
+        "name": "petStorage",
+        "desc": "Trivia is used to add field descriptions.\r",
+        "fields": [
+          {
+            "name": "entries",
+            "lua_type": "{petData}",
+            "desc": "Maximum size of 100."
+          },
+          {
+            "name": "size",
+            "lua_type": "number",
+            "desc": "Current size of `entries`."
+          },
+          {
+            "name": "lastAdded",
+            "lua_type": "number",
+            "desc": "Unix timestamp."
+          }
+        ],
+        "source": {
+          "line": 45,
+          "path": ""
+        }
+      },
+      {
+        "name": "petStorageUnreleased",
+        "desc": "Extra test for leading unpunctuated trivia.\r",
+        "fields": [
+          {
+            "name": "lastSizeChanged",
+            "lua_type": "number",
+            "desc": "Unix timestamp. Changes for insertions and deletions."
+          }
+        ],
+        "source": {
+          "line": 56,
+          "path": ""
+        }
+      },
+      {
+        "name": "petDatabase",
+        "desc": "`@field` can overwrite information on existing fields.\r",
+        "fields": [
+          {
+            "name": "get",
+            "lua_type": "(id: number) -> responseFull",
+            "desc": "Cached in [petStorage]."
+          },
+          {
+            "name": "set",
+            "lua_type": "(id:number,data:petData)->()",
+            "desc": "`id` must match `data.id`"
+          }
+        ],
+        "source": {
+          "line": 65,
           "path": ""
         }
       }

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -86,6 +86,11 @@ fn type_statement_inference() -> anyhow::Result<()> {
 }
 
 #[test]
+fn missing_fields() -> anyhow::Result<()> {
+    run_moonwave("failing/missing_fields.lua", 1)
+}
+
+#[test]
 fn failing_anomymous_function_assignment() -> anyhow::Result<()> {
     run_moonwave("failing/anonymous_function_assignment.lua", 1)
 }

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -81,6 +81,11 @@ fn anomymous_function_assignment() -> anyhow::Result<()> {
 }
 
 #[test]
+fn type_statement_inference() -> anyhow::Result<()> {
+    run_moonwave("passing/type_statement_inference.lua", 0)
+}
+
+#[test]
 fn failing_anomymous_function_assignment() -> anyhow::Result<()> {
     run_moonwave("failing/anonymous_function_assignment.lua", 1)
 }


### PR DESCRIPTION
I wanted to try contributing to Moonwave and this seemed relatively easy to add. However, my current implementation has everything be on one line, instead of one line per field. I am pretty sure writing the table type explicitly, such as `@type {id: number}` displays properly, so I am not sure why inferring using Full Moon's string representation does not.

Additionally, I am very new to Rust so feel free to nitpick on style or unidiomatic code. This code copies `TypeInfo` so that it can later be converted to a string - this sounds unnecessary to me but I could not see any other way to do it without using lifetimes, and considering the rest of the `DocEntryKind` enum does not use lifetimes, it would feel weird to use it just for the `Type` variation. Additionally, functions seem to copy strings?

I do not understand why `cargo install --path . --locked` needs to be run after every change while `cargo build` will not work (even if I call the executable with an absolute path to `target/release`). README.md mentions:

> You should now be able to change files in the `moonwave` folder

Maybe I am missing something but I do not see a folder titled "moonwave". Is this just referring to hot reload when you edit Luau files?

Thanks!

Closes https://github.com/evaera/moonwave/issues/155