### PR TITLE
Usage tags in type doc entries

### DIFF
--- a/extractor/test-input/passing/all_tags.lua
+++ b/extractor/test-input/passing/all_tags.lua
@@ -14,7 +14,7 @@
 
 	Here's a description for you
 
-	::: info
+	:::info
 	with an admonition
 	:::
 ]=]
@@ -80,6 +80,8 @@
 	@within Foo
 	@private
 	@ignore
+	@deprecated v2.0.0 -- We have finally removed all optional values from the library.
+	@since v0.1.0
 	@tag arrgh
 	@tag yarr
 
@@ -87,10 +89,20 @@
 ]=]
 
 --[=[
+	@type nilOrVector nil | vector
+	@within Bar
+	@unreleased
+
+	We are still experimenting with vector technology.
+]=]
+
+--[=[
 	@interface Command
 	@within Foo
 	@private
 	@ignore
+	@deprecated v0.7.3 -- Adding something that can break the universe was not such a good idea.
+	@since v0.7.2
 	@tag cmdr
 	@tag lua
 	@external OtherExample www.example.com
@@ -103,4 +115,17 @@
 	.Status Status -- Let's ignore that Promise:getStatus() exists
 
 	An object describing a command
+]=]
+
+--[=[
+	@interface Command2
+	@within Bar
+	@unreleased
+
+	.Name string -- The name of the command.
+	.Recursion Command2 -- No longer breaks the universe.
+	.Promise Promise -- A reference to the Promise library.
+	.Status Status -- The status of the internal promise.
+
+	We have fixed recursion! Unfortunately, it comes at the cost of groups.
 ]=]

--- a/extractor/tests/snapshots/test_inputs__passing__all_tags.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__all_tags.lua-stdout.snap
@@ -30,7 +30,49 @@ expression: stdout
         }
       }
     ],
-    "types": [],
+    "types": [
+      {
+        "name": "nilOrVector",
+        "desc": "We are still experimenting with vector technology.",
+        "lua_type": "nil | vector",
+        "unreleased": true,
+        "source": {
+          "line": 98,
+          "path": ""
+        }
+      },
+      {
+        "name": "Command2",
+        "desc": "We have fixed recursion! Unfortunately, it comes at the cost of groups.",
+        "fields": [
+          {
+            "name": "Name",
+            "lua_type": "string",
+            "desc": "The name of the command."
+          },
+          {
+            "name": "Recursion",
+            "lua_type": "Command2",
+            "desc": "No longer breaks the universe."
+          },
+          {
+            "name": "Promise",
+            "lua_type": "Promise",
+            "desc": "A reference to the Promise library."
+          },
+          {
+            "name": "Status",
+            "lua_type": "Status",
+            "desc": "The status of the internal promise."
+          }
+        ],
+        "unreleased": true,
+        "source": {
+          "line": 132,
+          "path": ""
+        }
+      }
+    ],
     "name": "Bar",
     "desc": "",
     "unreleased": true,
@@ -160,10 +202,15 @@ expression: stdout
           "arrgh",
           "yarr"
         ],
+        "since": "v0.1.0",
+        "deprecated": {
+          "version": "v2.0.0",
+          "desc": "We have finally removed all optional values from the library."
+        },
         "private": true,
         "ignore": true,
         "source": {
-          "line": 88,
+          "line": 90,
           "path": ""
         }
       },
@@ -211,16 +258,21 @@ expression: stdout
             "url": "www.example.com"
           }
         ],
+        "since": "v0.7.2",
+        "deprecated": {
+          "version": "v0.7.3",
+          "desc": "Adding something that can break the universe was not such a good idea."
+        },
         "private": true,
         "ignore": true,
         "source": {
-          "line": 107,
+          "line": 119,
           "path": ""
         }
       }
     ],
     "name": "Foo",
-    "desc": "Here's a description for you\n\n::: info\nwith an admonition\n:::",
+    "desc": "Here's a description for you\n\n:::info\nwith an admonition\n:::",
     "tags": [
       "bark",
       "meow",


### PR DESCRIPTION
Adds the option to use [usage tags](https://eryn.io/moonwave/docs/TagList/#usage-tags) in type doc entries. This uses the same behaviour as with other doc entries.

Relevant discussion: https://discord.com/channels/385151591524597761/894395472582676502/1339649852547797054