### PR TITLE
Make `@unreleased` mutually exclusive with `@deprecated`

### DIFF
--- a/extractor/src/tags/validation.rs
+++ b/extractor/src/tags/validation.rs
@@ -32,6 +32,7 @@ static MUTUALLY_EXCLUSIVE: &[(TagType, TagType)] = &[
     (TagType::Yields, TagType::Class),
     // Can't be unreleased and released at the same time
     (TagType::Unreleased, TagType::Since),
+    (TagType::Unreleased, TagType::Deprecated),
     // Readonly doesn't make sense on a function
     (TagType::Function, TagType::ReadOnly),
 ];

--- a/extractor/test-input/failing/class_with_unused_tags.lua
+++ b/extractor/test-input/failing/class_with_unused_tags.lua
@@ -3,4 +3,8 @@
 	@yields
 	@error E -- This
 	@return string -- a string
+
+	@unreleased
+	@since v0.1.0
+	@deprecated v1.0.0
 ]=]

--- a/extractor/tests/snapshots/test_inputs__failing__class_with_unused_tags.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__class_with_unused_tags.lua-stderr.snap
@@ -28,5 +28,21 @@ error: This tag is mutually exclusive...
 3 │     @yields
   │     ------- ...with this tag.
 
-error: aborting due to diagnostic error
+error: This tag is mutually exclusive...
+  ┌─ test-input/failing/class_with_unused_tags.lua:7:2
+  │
+7 │     @unreleased
+  │     ^^^^^^^^^^^ This tag is mutually exclusive...
+8 │     @since v0.1.0
+  │     ------------- ...with this tag.
 
+error: This tag is mutually exclusive...
+  ┌─ test-input/failing/class_with_unused_tags.lua:7:2
+  │
+7 │     @unreleased
+  │     ^^^^^^^^^^^ This tag is mutually exclusive...
+8 │     @since v0.1.0
+9 │     @deprecated v1.0.0
+  │     ------------------ ...with this tag.
+
+error: aborting due to diagnostic error


### PR DESCRIPTION
If something is unreleased, then it can not be deprecated, since deprecation is to mark something as not supported once it is already in use.

Relevant discussion: https://discord.com/channels/385151591524597761/894395472582676502/1348417437514858587

Other queries:

1. I wonder why this was commented out of mutually exclusive pairs:

```rust
    // Field is exclusive with function
    // (TagType::Field, TagType::Function),
```

2. There are a few cases where exclusive pairs involving `@interface` could be added, but this already errors due to "This tag is unused by X doc entries", which begs the question of whether explicit mutual exclusivity is really necessary.