### PR TITLE
Hide after line in README

### DIFF
--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -14,7 +14,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const TEMPLATE_PATH = path.join(__dirname, "../template")
 const ROOT_PATH = path.join(TEMPLATE_PATH, "root")
 
-const SNIP = "<!--moonwave-hide-before-this-line-->"
+const SNIP_BEFORE = "<!--moonwave-hide-before-this-line-->"
+const SNIP_AFTER = "<!--moonwave-hide-after-this-line-->"
 const INDEX_EXTS = ["html", "js", "mdx", "md"]
 const COPY_FOLDERS = ["blog", "docs", "pages"] as const
 
@@ -154,6 +155,25 @@ function getConfig(projectDir: string): Config {
   }
 }
 
+function prepareReadme(readmeContent: string): string {
+  const index_before = readmeContent.indexOf(SNIP_BEFORE)
+  const index_after = readmeContent.indexOf(SNIP_AFTER)
+
+  if (index_before > -1 && index_after > -1) {
+    return readmeContent.slice(0, index_after) + readmeContent.slice(index_before + SNIP_BEFORE.length)
+  }
+  
+  if (index_before > -1) {
+    return readmeContent.slice(index_before + SNIP_BEFORE.length)
+  }
+  
+  if (index_after > -1) {
+    return readmeContent.slice(0, index_after)
+  }
+
+  return readmeContent
+}
+
 function makeHomePage(projectDir: string, tempDir: string, config: Config) {
   if (
     INDEX_EXTS.filter((ext) =>
@@ -192,10 +212,7 @@ function makeHomePage(projectDir: string, tempDir: string, config: Config) {
 
         let readmeContent = fs.readFileSync(readmePath, { encoding: "utf-8" })
 
-        const snip = readmeContent.indexOf(SNIP)
-        if (snip > 0) {
-          readmeContent = readmeContent.slice(snip + SNIP.length)
-        }
+        readmeContent = prepareReadme(readmeContent)
 
         fs.writeFileSync(path.join(tempDir, "README.md"), readmeContent)
         indexSource = 'import README from "../README.md"\n' + indexSource
@@ -215,10 +232,7 @@ function makeHomePage(projectDir: string, tempDir: string, config: Config) {
       if (fs.existsSync(readmePath)) {
         let readmeContent = fs.readFileSync(readmePath, { encoding: "utf-8" })
 
-        const snip = readmeContent.indexOf(SNIP)
-        if (snip > 0) {
-          readmeContent = readmeContent.slice(snip + SNIP.length)
-        }
+        readmeContent = prepareReadme(readmeContent)
 
         fs.writeFileSync(indexPath, readmeContent)
       } else {

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -160,7 +160,11 @@ function prepareReadme(readmeContent: string): string {
   const index_after = readmeContent.indexOf(SNIP_AFTER)
 
   if (index_before > -1 && index_after > -1) {
-    return readmeContent.slice(0, index_after) + readmeContent.slice(index_before + SNIP_BEFORE.length)
+    if (index_after < index_before) {
+      return readmeContent.slice(0, index_after) + readmeContent.slice(index_before + SNIP_BEFORE.length)
+    } else {
+      return readmeContent.slice(index_before + SNIP_BEFORE.length, index_after)
+    }
   }
   
   if (index_before > -1) {

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -156,26 +156,25 @@ function getConfig(projectDir: string): Config {
 }
 
 function prepareReadme(readmeContent: string): string {
-  const index_before = readmeContent.indexOf(SNIP_BEFORE)
-  const index_after = readmeContent.indexOf(SNIP_AFTER)
+  while (true) {
+    const index_before = readmeContent.indexOf(SNIP_BEFORE)
+    const index_after = readmeContent.indexOf(SNIP_AFTER)
 
-  if (index_before > -1 && index_after > -1) {
-    if (index_after < index_before) {
-      return readmeContent.slice(0, index_after) + readmeContent.slice(index_before + SNIP_BEFORE.length)
+    if (index_before > -1) {
+      if (index_after > -1 && index_after < index_before) {
+        // snip text between comments
+        readmeContent = readmeContent.slice(0, index_after) + readmeContent.slice(index_before + SNIP_BEFORE.length)
+      } else {
+        // regular hide before
+        readmeContent = readmeContent.slice(index_before + SNIP_BEFORE.length)
+      }
+    } else if (index_after > -1) {
+      // can only handle a lone hide-after if no hide-before
+      readmeContent = readmeContent.slice(0, index_after)
     } else {
-      return readmeContent.slice(index_before + SNIP_BEFORE.length, index_after)
+      return readmeContent
     }
   }
-  
-  if (index_before > -1) {
-    return readmeContent.slice(index_before + SNIP_BEFORE.length)
-  }
-  
-  if (index_after > -1) {
-    return readmeContent.slice(0, index_after)
-  }
-
-  return readmeContent
 }
 
 function makeHomePage(projectDir: string, tempDir: string, config: Config) {

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -172,37 +172,24 @@ image = "https://url"
 
 Optionally, you can include `includeReadme = true`, which will append your project's README to the end of the home page.
 
-If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment.
+If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment. When `hide-after` is placed above `hide-before`, then only the content between them will be removed.
 
 ```html
-# AmazingProject
+Hide #1
 
 <!--moonwave-hide-before-this-line-->
 
-My project is amazing and it does everything you could ever want.
+Show #1
 
 <!--moonwave-hide-after-this-line-->
 
-Copyrighted under the MIT License.
-```
-
-Only the content underneath/above the HTML comment will be included in your Moonwave homepage.
-
-When both comments are used and `hide-after` is placed above `hide-before`, then only the content between them will be removed.
-
-```html
-[badges/github]: link to image
-[project]: link to repository
-
-<!--moonwave-hide-after-this-line-->
-
-# TestingProject
+Hide #2
 
 <!--moonwave-hide-before-this-line-->
 
-[![Source code][badges/github]][project]
+Show #2
 
-My project fulfills all your testing needs.
+<!--moonwave-hide-after-this-line-->
+
+Hide #3
 ```
-
-Keep in mind that both `hide-before` and `hide-after` can only be used once each in a README.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -172,24 +172,26 @@ image = "https://url"
 
 Optionally, you can include `includeReadme = true`, which will append your project's README to the end of the home page.
 
-If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment. When `hide-after` is placed above `hide-before`, then only the content between them will be removed.
+If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment.
 
 ```html
-Hide #1
-
+All content behind this comment will be hidden.
 <!--moonwave-hide-before-this-line-->
 
-Show #1
+While everything in between both comments will be visible!
 
 <!--moonwave-hide-after-this-line-->
+And everything ahead of this comment will also be hidden.
+```
 
-Hide #2
+You can also combine both HTML tags to hide things in the middle of your content.
+
+```html
+The beginning of my content will be visible.
+<!--moonwave-hide-after-this-line-->
+
+This content will be hidden.
 
 <!--moonwave-hide-before-this-line-->
-
-Show #2
-
-<!--moonwave-hide-after-this-line-->
-
-Hide #3
+While the rest of my content will also be visible.
 ```

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -172,12 +172,14 @@ image = "https://url
 
 Optionally, you can include `includeReadme = true`, which will append your project's README to the end of the home page.
 
-If your project's README begins with some content that you don't want included in your home page, you can place an HTML comment in your project's README that will not include any content before it.
+If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment.
 
 ```html
 Project Logo, Project Name, Etc
 <!--moonwave-hide-before-this-line-->
 My project is amazing and it does everything you could ever want.
+<!--moonwave-hide-after-this-line-->
+License Information
 ```
 
-Only the content underneath the HTML comment will be included in your Moonwave homepage.
+Only the content underneath/above the HTML comment will be included in your Moonwave homepage.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -175,11 +175,15 @@ Optionally, you can include `includeReadme = true`, which will append your proje
 If your project's README contains content that you don't want included in your home page, you can place HTML comments in your project's README to remove any content before/after the comment.
 
 ```html
-Project Logo, Project Name, Etc
+# AmazingProject
+
 <!--moonwave-hide-before-this-line-->
+
 My project is amazing and it does everything you could ever want.
+
 <!--moonwave-hide-after-this-line-->
-License Information
+
+Copyrighted under the MIT License.
 ```
 
 Only the content underneath/above the HTML comment will be included in your Moonwave homepage.
@@ -192,7 +196,7 @@ When both comments are used and `hide-after` is placed above `hide-before`, then
 
 <!--moonwave-hide-after-this-line-->
 
-# Project name
+# TestingProject
 
 <!--moonwave-hide-before-this-line-->
 
@@ -200,3 +204,5 @@ When both comments are used and `hide-after` is placed above `hide-before`, then
 
 My project fulfills all your testing needs.
 ```
+
+Keep in mind that both `hide-before` and `hide-after` can only be used once each in a README.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -162,12 +162,12 @@ bannerImage = "https://url" # Optional
 [[home.features]]
 title = "Feature 1"
 description = "This is a feature"
-image = "https://url
+image = "https://url"
 
 [[home.features]]
 title = "Feature 2"
 description = "This is a second feature"
-image = "https://url
+image = "https://url"
 ```
 
 Optionally, you can include `includeReadme = true`, which will append your project's README to the end of the home page.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -184,7 +184,7 @@ While everything in between both comments will be visible!
 And everything ahead of this comment will also be hidden.
 ```
 
-You can also combine both HTML tags to hide things in the middle of your content.
+You can also combine both HTML tags to hide things in the middle of your README.
 
 ```html
 The beginning of my content will be visible.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -183,3 +183,20 @@ License Information
 ```
 
 Only the content underneath/above the HTML comment will be included in your Moonwave homepage.
+
+When both comments are used and `hide-after` is placed above `hide-before`, then only the content between them will be removed.
+
+```html
+[badges/github]: link to image
+[project]: link to repository
+
+<!--moonwave-hide-after-this-line-->
+
+# Project name
+
+<!--moonwave-hide-before-this-line-->
+
+[![Source code][badges/github]][project]
+
+My project fulfills all your testing needs.
+```


### PR DESCRIPTION
Adds `<!--moonwave-hide-after-this-line-->` to hide all proceeding content. However, if one writes `hide-after` and later `hide-before`, then only the text in between the two comments will be removed.

I had trouble describing the feature on the Moonwave documentation website. I think I explained all the details, but it just sounds a bit off. Maybe I am being too much of a perfectionist.

I was unable to test the website. I tried following the [README](https://github.com/evaera/moonwave/blob/master/website/README.md) but got some massive error that filled the console to the point where I could not scroll to the top of it. The portion that I saw was a bunch of code. I then tried using NPM, with `npm i` and `npm run start`, and then even `npm run build`, but they too resulted in the same error.

Closes https://github.com/evaera/moonwave/issues/114