### PR TITLE
Nested sections

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/Redirect.js
+++ b/docusaurus-plugin-moonwave/src/components/Redirect.js
@@ -1,21 +1,42 @@
 import { Redirect as RouterRedirect } from "@docusaurus/router"
 import React from "react"
 
-export default function Redirect({ sidebarClassNames, pluginOptions }) {
-  for (let index = 0; index < sidebarClassNames.length; index++) {
-    const element = sidebarClassNames[index]
-    if (element.type == "category" && element.items.length === 0) {
+// Find the first valid link in a potentially nested sidebar structure
+function findFirstValidLink(items) {
+  for (let index = 0; index < items.length; index++) {
+    const element = items[index]
+
+    // Skip empty categories
+    if (element.type === "category" && element.items.length === 0) {
       continue
     }
 
-    const firstLuaClassName = (
-      element.type === "link" ? element.label : element.items[0].label
-    ).replace(/[\u200B]/g, "") // Strip out any extraneous 0-width spaces
+    // If it's a link, return the label (class name)
+    if (element.type === "link") {
+      return element.label.replace(/[\u200B]/g, "") // Strip out any zero-width spaces
+    }
 
+    // If it's a category, recursively look for the first link in its items
+    if (element.type === "category") {
+      const nestedLink = findFirstValidLink(element.items)
+      if (nestedLink) {
+        return nestedLink
+      }
+    }
+  }
+
+  return null // No valid link found
+}
+
+export default function Redirect({ sidebarClassNames, pluginOptions }) {
+  const firstLuaClassName = findFirstValidLink(sidebarClassNames)
+
+  if (firstLuaClassName) {
     return (
       <RouterRedirect to={`${pluginOptions.baseUrl}api/${firstLuaClassName}`} />
     )
   }
 
+  // No valid link found, redirect to 404
   return <RouterRedirect to={`${pluginOptions.baseUrl}api/404`} />
 }

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -69,34 +69,52 @@ function parseSectionalClassOrder(content, classOrder, filteredContent) {
   filteredContent.forEach((luaClass) => nameSet.add(luaClass.name))
 
   const listedNames = []
-
   const listedSidebar = []
+
   classOrder.forEach((element) => {
-    const namesWithTags = filteredContent
-      .filter((luaClass) =>
-        luaClass.tags ? luaClass.tags.includes(element.tag) : false
+    if (element.items && Array.isArray(element.items)) {
+      const childItems = processNestedItems(
+        element.items,
+        nameSet,
+        filteredContent,
+        listedNames
       )
-      .map((luaClass) => luaClass.name)
-    const namesIncludedInClasses = element.classes || []
 
-    const tagsItems = mapLinksByName(nameSet, namesWithTags)
-    const classesItems = mapLinksByName(nameSet, namesIncludedInClasses)
-
-    if (element.section) {
+      // Create parent category with nested children
       listedSidebar.push({
         type: "category",
         label: element.section,
         collapsible: true,
         collapsed: element.collapsed ?? true,
-        items: [...classesItems, ...tagsItems],
+        items: childItems,
       })
     } else {
-      const toPush = [...classesItems, ...tagsItems]
-      listedSidebar.push(...toPush)
-    }
+      const namesWithTags = filteredContent
+        .filter((luaClass) =>
+          luaClass.tags ? luaClass.tags.includes(element.tag) : false
+        )
+        .map((luaClass) => luaClass.name)
+      const namesIncludedInClasses = element.classes || []
 
-    const toPush = [...namesWithTags, ...namesIncludedInClasses]
-    listedNames.push(...toPush)
+      const tagsItems = mapLinksByName(nameSet, namesWithTags)
+      const classesItems = mapLinksByName(nameSet, namesIncludedInClasses)
+
+      if (element.section) {
+        listedSidebar.push({
+          type: "category",
+          label: element.section,
+          collapsible: true,
+          collapsed: element.collapsed ?? true,
+          items: [...classesItems, ...tagsItems],
+        })
+      } else {
+        const toPush = [...classesItems, ...tagsItems]
+        listedSidebar.push(...toPush)
+      }
+
+      const toPush = [...namesWithTags, ...namesIncludedInClasses]
+      listedNames.push(...toPush)
+    }
   })
 
   const unlistedSidebar = content
@@ -130,6 +148,65 @@ function parseClassOrder(content, classOrder, filteredContent) {
     // Handles cases where classOrder is assigned via TOML tables
     return parseSectionalClassOrder(content, classOrder, filteredContent)
   }
+}
+
+function processNestedItems(items, nameSet, filteredContent, listedNames) {
+  const result = []
+
+  items.forEach((item) => {
+    // If item has a nested section
+    if (item.section) {
+      const childItems = []
+
+      // Handle classes directly under this section
+      if (item.classes && Array.isArray(item.classes)) {
+        const classesItems = mapLinksByName(nameSet, item.classes)
+        childItems.push(...classesItems)
+        listedNames.push(...item.classes)
+      }
+
+      // Handle tagged classes
+      if (item.tag) {
+        const namesWithTags = filteredContent
+          .filter((luaClass) =>
+            luaClass.tags ? luaClass.tags.includes(item.tag) : false
+          )
+          .map((luaClass) => luaClass.name)
+
+        const tagsItems = mapLinksByName(nameSet, namesWithTags)
+        childItems.push(...tagsItems)
+        listedNames.push(...namesWithTags)
+      }
+
+      // Handle further nested items recursively
+      if (item.items && Array.isArray(item.items)) {
+        const nestedItems = processNestedItems(
+          item.items,
+          nameSet,
+          filteredContent,
+          listedNames
+        )
+        childItems.push(...nestedItems)
+      }
+
+      // Add this section to the result
+      result.push({
+        type: "category",
+        label: item.section,
+        collapsible: true,
+        collapsed: item.collapsed ?? true,
+        items: childItems,
+      })
+    }
+    // If item just has classes (no section)
+    else if (item.classes && Array.isArray(item.classes)) {
+      const classesItems = mapLinksByName(nameSet, item.classes)
+      result.push(...classesItems)
+      listedNames.push(...item.classes)
+    }
+  })
+
+  return result
 }
 
 function parseApiCategories(luaClass, apiCategories) {
@@ -257,6 +334,54 @@ async function generateTypeLinks(nameSet, luaClasses, baseUrl) {
   }
 
   return typeLinks
+}
+
+function validateNestedItems(items, path) {
+  items.forEach((item, index) => {
+    const currentPath = `${path}[${index}]`
+
+    // Validate section name
+    if (item.section && typeof item.section !== "string") {
+      throw new Error(
+        `Moonwave plugin: expected ${currentPath}.section to be a string.`
+      )
+    }
+
+    // Validate classes array
+    if (item.classes !== undefined) {
+      if (!Array.isArray(item.classes)) {
+        throw new Error(
+          `Moonwave plugin: expected ${currentPath}.classes to be an array.`
+        )
+      }
+
+      item.classes.forEach((className, classIndex) => {
+        if (typeof className !== "string") {
+          throw new Error(
+            `Moonwave plugin: expected ${currentPath}.classes[${classIndex}] to be a string.`
+          )
+        }
+      })
+    }
+
+    // Validate tag
+    if (item.tag !== undefined && typeof item.tag !== "string") {
+      throw new Error(
+        `Moonwave plugin: expected ${currentPath}.tag to be a string.`
+      )
+    }
+
+    // Recursively validate nested items
+    if (item.items !== undefined) {
+      if (!Array.isArray(item.items)) {
+        throw new Error(
+          `Moonwave plugin: expected ${currentPath}.items to be an array.`
+        )
+      }
+
+      validateNestedItems(item.items, `${currentPath}.items`)
+    }
+  })
 }
 
 export default (context, options) => ({
@@ -459,6 +584,15 @@ export function validateOptions({ options }) {
     throw new Error(
       "Moonwave plugin: expected option `projectDir` to be a string."
     )
+  }
+
+  if (options.classOrder && Array.isArray(options.classOrder)) {
+    options.classOrder.forEach((section, index) => {
+      // If there are nested items
+      if (section.items && Array.isArray(section.items)) {
+        validateNestedItems(section.items, `classOrder[${index}].items`)
+      }
+    })
   }
 
   if (!Array.isArray(options.code)) {

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -73,6 +73,10 @@ function parseSectionalClassOrder(content, classOrder, filteredContent) {
 
   classOrder.forEach((element) => {
     if (element.items && Array.isArray(element.items)) {
+      // Handle both direct classes and nested items
+      const directClasses = element.classes || []
+      const directClassItems = mapLinksByName(nameSet, directClasses)
+
       const childItems = processNestedItems(
         element.items,
         nameSet,
@@ -80,15 +84,21 @@ function parseSectionalClassOrder(content, classOrder, filteredContent) {
         listedNames
       )
 
-      // Create parent category with nested children
+      // Combine direct classes with nested items
+      const allItems = [...directClassItems, ...childItems]
+
       listedSidebar.push({
         type: "category",
         label: element.section,
         collapsible: true,
         collapsed: element.collapsed ?? true,
-        items: childItems,
+        items: allItems,
       })
+
+      // Add direct classes to listed names
+      listedNames.push(...directClasses)
     } else {
+      // Handle sections without nested items (existing logic)
       const namesWithTags = filteredContent
         .filter((luaClass) =>
           luaClass.tags ? luaClass.tags.includes(element.tag) : false

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -113,24 +113,28 @@ You can create hierarchical organization with nested sections:
 ```toml
 [[classOrder]]
 section = "Parent Section"
-items = [
-  # Child section with classes
-  { section = "Child Section 1", classes = ["Class1", "Class2"] },
-  
-  # Child section with tagged classes
-  { section = "Child Section 2", tag = "childTag" },
-  
-  # Classes directly under Parent Section (no subsection)
-  { classes = ["Class3"] },
-  
-  # Deeper nesting with grandchild section
-  { 
-    section = "Child Section 3", 
-    items = [
-      { section = "Grandchild Section", classes = ["Class4", "Class5"] }
-    ]
-  }
-]
+
+# Child section with classes
+[[classOrder.items]]
+section = "Child Section 1"
+classes = ["Class1", "Class2"]
+
+# Child section with tagged classes
+[[classOrder.items]]
+section = "Child Section 2"
+tag = "childTag"
+
+# Classes directly under Parent Section (no subsection)
+[[classOrder.items]]
+classes = ["Class3"]
+
+# Deeper nesting with grandchild section
+[[classOrder.items]]
+section = "Child Section 3"
+
+[[classOrder.items.items]]
+section = "Grandchild Section"
+classes = ["Class4", "Class5"]
 
 # The original format still works alongside nested sections
 [[classOrder]]
@@ -144,13 +148,11 @@ You can control the collapsed state at any nesting level:
 [[classOrder]]
 section = "Always Expanded"
 collapsed = false
-items = [
-  { 
-    section = "Always Collapsed Child", 
-    collapsed = true, 
-    classes = ["Class1"] 
-  }
-]
+
+[[classOrder.items]]
+section = "Always Collapsed Child"
+collapsed = true
+classes = ["Class1"]
 ```
 
 Nested sections support all the same features as top-level sections, including class lists, tags, and collapse control, at any level of nesting.

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -82,9 +82,7 @@ classOrder = [
 Any classes not listed here will be alphabetized and added to the end of the list. Listing a class that doesn't exist is an error.
 
 ### Sections
-
 You can categorize your API pages with sections. Instead of the above style, you can do this:
-
 ```toml
 [[classOrder]]
 section = "Section name"
@@ -108,6 +106,54 @@ section = "Yet another section name"
 collapsed = false # Determines with the section grouping is collapsed or expanded on page load. Defaults to true.
 classes = ["Class7", "ClassAte", "Class9"]
 ```
+
+### Nested Sections
+You can create hierarchical organization with nested sections:
+
+```toml
+[[classOrder]]
+section = "Parent Section"
+items = [
+  # Child section with classes
+  { section = "Child Section 1", classes = ["Class1", "Class2"] },
+  
+  # Child section with tagged classes
+  { section = "Child Section 2", tag = "childTag" },
+  
+  # Classes directly under Parent Section (no subsection)
+  { classes = ["Class3"] },
+  
+  # Deeper nesting with grandchild section
+  { 
+    section = "Child Section 3", 
+    items = [
+      { section = "Grandchild Section", classes = ["Class4", "Class5"] }
+    ]
+  }
+]
+
+# The original format still works alongside nested sections
+[[classOrder]]
+section = "Regular Section"
+classes = ["Class6", "Class7"]
+```
+
+You can control the collapsed state at any nesting level:
+
+```toml
+[[classOrder]]
+section = "Always Expanded"
+collapsed = false
+items = [
+  { 
+    section = "Always Collapsed Child", 
+    collapsed = true, 
+    classes = ["Class1"] 
+  }
+]
+```
+
+Nested sections support all the same features as top-level sections, including class lists, tags, and collapse control, at any level of nesting.
 
 #### Automatic Sections from Folders
 


### PR DESCRIPTION
Adds the option to nest API sections within eachother and updates the docs to reflect the new feature.

Example:
```
[[classOrder]]
section = "Traditional Section"
classes = ["Class1", "Class2"]  # Works as before

[[classOrder]]
section = "Nested Section"
items = [
  { section = "Sub-Section", classes = ["Class3"] }
]
```