### PR TITLE
Homepage button configuration

### DIFF
--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -78,6 +78,11 @@ export type Config = Partial<{
       description: string
       image: string
     }[]
+
+    buttons: {
+      text: string
+      url: string
+    }[]
   }>
 
   footer: Partial<{
@@ -175,11 +180,19 @@ function makeHomePage(projectDir: string, tempDir: string, config: Config) {
         return feature
       })
 
+      let buttons = config.home?.buttons ?? [
+        {
+          text: "Get Started →",
+          url: "/docs/intro"
+        }
+      ]
+
       let indexSource = fs
         .readFileSync(path.join(TEMPLATE_PATH, "home", "index.js"), {
           encoding: "utf-8",
         })
         .replace("/***features***/", JSON.stringify(features ?? null))
+        .replace("/***buttons***/", JSON.stringify(buttons))
 
       const readmePath = path.join(
         projectDir,

--- a/cli/template/home/index.js
+++ b/cli/template/home/index.js
@@ -39,6 +39,19 @@ export function HomepageFeatures() {
   )
 }
 
+const BUTTONS = /***buttons***/
+
+function Button({ text, url }) {
+  return (
+    <Link
+      className="button button--secondary button--lg"
+      to={url}
+    >
+      {text}
+    </Link>
+  )
+}
+
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext()
   const bannerImage = siteConfig.customFields.bannerImage
@@ -58,12 +71,9 @@ function HomepageHeader() {
         <h1 className={titleClassName}>{siteConfig.title}</h1>
         <p className={taglineClassName}>{siteConfig.tagline}</p>
         <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/intro"
-          >
-            Get Started →
-          </Link>
+          {BUTTONS.map((props) => (
+            <Button {...props} />
+          ))}
         </div>
       </div>
     </header>

--- a/cli/template/home/index.js
+++ b/cli/template/home/index.js
@@ -7,21 +7,21 @@ import styles from "./index.module.css"
 
 const FEATURES = /***features***/
 
-  function Feature({ image, title, description }) {
-    return (
-      <div className={clsx("col col--4")}>
-        {image && (
-          <div className="text--center">
-            <img className={styles.featureSvg} alt={title} src={image} />
-          </div>
-        )}
-        <div className="text--center padding-horiz--md">
-          <h3>{title}</h3>
-          <p>{description}</p>
+function Feature({ image, title, description }) {
+  return (
+    <div className={clsx("col col--4")}>
+      {image && (
+        <div className="text--center">
+          <img className={styles.featureSvg} alt={title} src={image} />
         </div>
+      )}
+      <div className="text--center padding-horiz--md">
+        <h3>{title}</h3>
+        <p>{description}</p>
       </div>
-    )
-  }
+    </div>
+  )
+}
 
 export function HomepageFeatures() {
   if (!FEATURES) return null

--- a/cli/template/home/index.js
+++ b/cli/template/home/index.js
@@ -46,6 +46,9 @@ function Button({ text, url }) {
     <Link
       className="button button--secondary button--lg"
       to={url}
+      style={{
+        margin: "5px"
+      }}
     >
       {text}
     </Link>

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -168,6 +168,15 @@ image = "https://url
 title = "Feature 2"
 description = "This is a second feature"
 image = "https://url
+
+# This is the default button. Adding any buttons will remove it, so this code adds it back.
+[[home.buttons]]
+text = "Get Started →"
+url = "/docs/intro"
+
+[[home.buttons]]
+text = "Download"
+url = "https://url"
 ```
 
 Optionally, you can include `includeReadme = true`, which will append your project's README to the end of the home page.


### PR DESCRIPTION
Adds the ability to add buttons to the default homepage via `moonwave.toml`.

```toml
[[home.buttons]]
text = "Download"
url = "https://github.com/evaera/moonwave/releases/download/v1.3.0/moonwave-extractor-v1.3.0-linux.zip"
```

Adding any buttons will remove the default "Get Started", so the equivalent TOML code for it is included on the website.

I was not sure how to properly add a margin between homepage buttons so I just used an inline style.

Closes https://github.com/evaera/moonwave/issues/105