### PR TITLE
Use qualified names when `@within` is omitted

### DIFF
--- a/docusaurus-plugin-moonwave/src/components/LuaTypeDef.js
+++ b/docusaurus-plugin-moonwave/src/components/LuaTypeDef.js
@@ -24,14 +24,14 @@ const Interface = ({ name, fields }) => (
     <code>
       {name} {"{"}
     </code>
-    <div className={styles.inset}>
+    {fields && <div className={styles.inset}>
       {fields.map(({ name, lua_type: luaType, desc }) => (
         <div key={name}>
           <Param name={name} luaType={luaType} />
           {desc && <InlineDescription content={desc} />}
         </div>
       ))}
-    </div>
+    </div>}
     <code>{"}"}</code>
   </>
 )

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -65,7 +65,7 @@ struct DocEntryParseArguments<'a> {
     source: &'a DocComment,
 }
 
-fn get_explicit_within<'a>(tags: &'a [Tag]) -> Option<String> {
+fn get_explicit_within(tags: &[Tag]) -> Option<String> {
     for tag in tags {
         if let Tag::Within(within_tag) = tag {
             return Some(within_tag.name.as_str().to_owned());
@@ -75,7 +75,7 @@ fn get_explicit_within<'a>(tags: &'a [Tag]) -> Option<String> {
     None
 }
 
-fn get_qualified_within(name: &String) -> Option<(String, String)> {
+fn get_qualified_within(name: &str) -> Option<(String, String)> {
     if let Some((first, second)) = name.split_once(".") {
         if !first.is_empty() && !second.is_empty() {
             return Some((first.to_owned(), second.to_owned()));
@@ -85,8 +85,8 @@ fn get_qualified_within(name: &String) -> Option<(String, String)> {
     None
 }
 
-fn get_within_and_name<'a>(
-    tags: &'a [Tag],
+fn get_within_and_name(
+    tags: &[Tag],
     kind_tag: &Tag,
     name: String,
 ) -> Result<(String, String), Diagnostic> {

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -78,20 +78,24 @@ fn get_explicit_within<'a>(tags: &'a [Tag]) -> Option<String> {
 fn get_qualified_within(name: &String) -> Option<(String, String)> {
     if let Some((first, second)) = name.split_once(".") {
         if !first.is_empty() && !second.is_empty() {
-            return Some((first.to_owned(), second.to_owned()))
+            return Some((first.to_owned(), second.to_owned()));
         }
     }
 
     None
 }
 
-fn get_within_and_name<'a>(tags: &'a [Tag], kind_tag: &Tag, name: String) -> Result<(String, String), Diagnostic> {
+fn get_within_and_name<'a>(
+    tags: &'a [Tag],
+    kind_tag: &Tag,
+    name: String,
+) -> Result<(String, String), Diagnostic> {
     if let Some(within) = get_explicit_within(tags) {
-        return Ok((within, name))
+        return Ok((within, name));
     }
 
     if let Some(results) = get_qualified_within(&name) {
-        return Ok(results)
+        return Ok(results);
     }
 
     Err(kind_tag.diagnostic("Must specify containing class with @within tag"))
@@ -118,26 +122,17 @@ fn get_explicit_kind(tags: &[Tag]) -> Result<Option<DocEntryKind>, Diagnostic> {
             Tag::Property(property_tag) => {
                 let name = property_tag.name.as_str().to_owned();
                 let (within, name) = get_within_and_name(tags, tag, name)?;
-                return Ok(Some(DocEntryKind::Property {
-                    name,
-                    within,
-                }))
+                return Ok(Some(DocEntryKind::Property { name, within }));
             }
             Tag::Type(type_tag) => {
                 let name = type_tag.name.as_str().to_owned();
                 let (within, name) = get_within_and_name(tags, tag, name)?;
-                return Ok(Some(DocEntryKind::Type {
-                    name,
-                    within,
-                }))
+                return Ok(Some(DocEntryKind::Type { name, within }));
             }
             Tag::Interface(interface_tag) => {
                 let name = interface_tag.name.as_str().to_owned();
                 let (within, name) = get_within_and_name(tags, tag, name)?;
-                return Ok(Some(DocEntryKind::Type {
-                    name,
-                    within,
-                }))
+                return Ok(Some(DocEntryKind::Type { name, within }));
             }
             _ => (),
         }

--- a/extractor/src/tags/validation.rs
+++ b/extractor/src/tags/validation.rs
@@ -37,10 +37,7 @@ static MUTUALLY_EXCLUSIVE: &[(TagType, TagType)] = &[
     (TagType::Function, TagType::ReadOnly),
 ];
 
-static DEPENDENT_TAGS: &[(TagType, TagType)] = &[
-    (TagType::Property, TagType::Within),
-    (TagType::Type, TagType::Within),
-];
+static DEPENDENT_TAGS: &[(TagType, TagType)] = &[]; // Was used in the past
 
 static ALLOW_MULTIPLE: &[TagType] = &[
     TagType::Param,

--- a/extractor/test-input/passing/qualified_names.lua
+++ b/extractor/test-input/passing/qualified_names.lua
@@ -1,0 +1,18 @@
+--- @class QualifiedNames
+
+--- @function QualifiedNames.function
+
+--- @prop QualifiedNames.prop number
+
+--- @prop QualifiedNames.lots.of.dots number
+
+--- @type QualifiedNames.type number
+
+--- @interface QualifiedNames.interface
+
+
+
+--- @class ExplicitWithin
+
+--- @prop QualifiedNames.differentClass number
+--- @within ExplicitWithin

--- a/extractor/tests/snapshots/test_inputs__passing__qualified_names.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__qualified_names.lua-stderr.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__qualified_names.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__qualified_names.lua-stdout.snap
@@ -1,0 +1,87 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+[
+  {
+    "functions": [],
+    "properties": [
+      {
+        "name": "QualifiedNames.differentClass",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 19,
+          "path": ""
+        }
+      }
+    ],
+    "types": [],
+    "name": "ExplicitWithin",
+    "desc": "",
+    "source": {
+      "line": 16,
+      "path": ""
+    }
+  },
+  {
+    "functions": [
+      {
+        "name": "function",
+        "desc": "",
+        "params": [],
+        "returns": [],
+        "function_type": "static",
+        "source": {
+          "line": 4,
+          "path": ""
+        }
+      }
+    ],
+    "properties": [
+      {
+        "name": "prop",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 6,
+          "path": ""
+        }
+      },
+      {
+        "name": "lots.of.dots",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 8,
+          "path": ""
+        }
+      }
+    ],
+    "types": [
+      {
+        "name": "type",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 10,
+          "path": ""
+        }
+      },
+      {
+        "name": "interface",
+        "desc": "",
+        "source": {
+          "line": 12,
+          "path": ""
+        }
+      }
+    ],
+    "name": "QualifiedNames",
+    "desc": "",
+    "source": {
+      "line": 2,
+      "path": ""
+    }
+  }
+]

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -42,6 +42,11 @@ fn method_stmt_with_within() -> anyhow::Result<()> {
 }
 
 #[test]
+fn qualified_names() -> anyhow::Result<()> {
+    run_moonwave("passing/qualified_names.lua", 0)
+}
+
+#[test]
 fn class_with_index() -> anyhow::Result<()> {
     run_moonwave("passing/class_with_index.lua", 0)
 }


### PR DESCRIPTION
Allows for skipping `@within` by including the class name in the tag text.

```luau
--- @prop QualifiedNames.prop number
```

The code checks for the first dot (.), so this is legal:
```luau
--- @prop QualifiedNames.lots.of.dots number
```
```json
   "name": "lots.of.dots"
```

I decided to support `@type` and `@interface` too because it made implementation easier. This renders `DEPENDENT_TAGS` empty, but I think it is good to keep for the future.

I also sneaked in a bug fix for empty interfaces since I used one for the test and I like to preview tests on the website.

I think there should be some mention of this on the website, but right now inference is kind of all over the place, so maybe there could be a new heading detailing exactly what is inferred?

Closes https://github.com/evaera/moonwave/issues/5