### PR TITLE
Reduce noise when Extractor fails in the Docusaurus Plugin

### DIFF
--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -286,11 +286,18 @@ export default (context, options) => ({
             maxBuffer: 10 * 1024 * 1024,
           }
         )
-          .then((raw) => JSON.parse(raw))
+          .then(({ stdout, stderr }) => {
+            if (stderr.length > 0) {
+              return Promise.reject(stderr)
+            }
+
+            return stdout
+          })
           .catch(({ stderr }) => {
             console.error(`\n${stderr}`)
             return Promise.reject(`Moonwave: Failed to extract. Check the error above.`)
           })
+          .then((raw) => JSON.parse(raw))
       )
     )
 

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -286,14 +286,11 @@ export default (context, options) => ({
             maxBuffer: 10 * 1024 * 1024,
           }
         )
-          .then(({ stdout, stderr }) => {
-            if (stderr.length > 0) {
-              return Promise.reject(stderr)
-            }
-
-            return stdout
-          })
           .then((raw) => JSON.parse(raw))
+          .catch(({ stderr }) => {
+            console.error(`\n${stderr}`)
+            return Promise.reject(`Moonwave: Failed to extract. Check the error above.`)
+          })
       )
     )
 


### PR DESCRIPTION
When the Docusaurus Moonwave Plugin fails to extract using the Moonwave Extractor, it will display irrelevant information to the user. This information includes the Node stack trace and the Extractor's raw stderr output, which creates a lot of unnecessary noise.

This PR removes all this unnecessary noise, and replaces the error message with:
```[ERROR] 'Moonwave: Failed to extract. Check the error above.'```