### PR TITLE
Only watch necessary files

### DIFF
--- a/cli/src/commands/dev.ts
+++ b/cli/src/commands/dev.ts
@@ -22,7 +22,7 @@ export default async function devCommand(args: Args) {
     )
 
     chokidar
-      .watch(projectDir, {
+      .watch(watchPaths, {
         ignoreInitial: true,
       })
       .on("all", (event, changedPath) => {


### PR DESCRIPTION
Rather than watch `projectDir` and all of its descendants, this pull request changes it so that the CLI watches `projectDir` shallowly and watches everything in `watchPaths` deeply. This means that new relevant items are detected, such as `./pages`, while ignoring anything beyond that, such as ignoring the descendants of `./node_modules`.

I am pretty sure everything else behaves the same, but it is hard to tell. I *did* come across some things that seem strange while testing, but it appears that these existed before, so it is not a regression. Here are the issues:
- The topbar navigation buttons for changelog, blog, et cetera do not hot reload. If these things exist when starting the local site, they persist even if the relevant files are deleted. Similarly, if they do not exist when starting the local site, they will never create topbar buttons, though the pages still work, that is, <http://localhost:3000/changelog> would be available if `CHANGELOG.md` is added after starting the local site.
- If the website started with `./docs/intro.md`, then removing/renaming it causes an error until it is returned.
- There is an option for enabling the changelog in `moonwave.toml`, but it does not matter because it is always set to `true`: https://github.com/evaera/moonwave/blob/6b24dde30a15c7b0c825c431c35f5122a4cd0534/cli/src/prepareProject.ts#L140

I am curious as to where the program says to watch changes to `./src` / `./lib` since these are not included in `watchPaths`.

On a side note, I think `moonwave.json` is not mentioned anywhere on the website, even though it is valid as the fallback configuration file if `moonwave.toml` is missing.

Closes https://github.com/evaera/moonwave/issues/178