### PR TITLE
Add option for Roblox API dump source

### DIFF
--- a/cli/src/getDocusaurusConfig.ts
+++ b/cli/src/getDocusaurusConfig.ts
@@ -14,6 +14,7 @@ export interface GenerateConfigParams {
   classOrder: ClassOrder
   apiCategories: string[]
   autoSectionPath?: string
+  apiDumpUrl?: string
 }
 
 export default function getDocusaurusConfig({
@@ -28,6 +29,7 @@ export default function getDocusaurusConfig({
   classOrder,
   apiCategories,
   autoSectionPath,
+  apiDumpUrl,
 }: GenerateConfigParams) {
   const gitRepoUrl = config.gitRepoUrl
 
@@ -120,6 +122,7 @@ export default function getDocusaurusConfig({
           apiCategories,
           binaryPath,
           autoSectionPath,
+          apiDumpUrl,
         },
       ],
       "docusaurus-lunr-search",

--- a/cli/src/prepareProject.ts
+++ b/cli/src/prepareProject.ts
@@ -49,6 +49,7 @@ export type Config = Partial<{
   classOrder: ClassOrder
   apiCategories: string[]
   autoSectionPath?: string
+  apiDumpUrl: string
 
   // Docusaurus
   docusaurus: Partial<{
@@ -452,6 +453,7 @@ export function prepareProject(
     classOrder: config.classOrder ?? [],
     apiCategories: config.apiCategories ?? [],
     autoSectionPath: config.autoSectionPath,
+    apiDumpUrl: config.apiDumpUrl,
   })
 
   if (

--- a/docusaurus-plugin-moonwave/src/generateRobloxTypes.js
+++ b/docusaurus-plugin-moonwave/src/generateRobloxTypes.js
@@ -42,9 +42,9 @@ const dataTypes = [
   "Vector3int16",
 ]
 
-export async function generateRobloxTypes() {
+export async function generateRobloxTypes(apiDumpUrl) {
   const req = await fetch(
-    "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Watch/roblox/API-Dump.json"
+    apiDumpUrl ?? "https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Watch/roblox/API-Dump.json"
   )
 
   const api = await req.json()

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -211,7 +211,7 @@ function parseApiCategories(luaClass, apiCategories) {
   return [...tocData]
 }
 
-async function generateTypeLinks(nameSet, luaClasses, baseUrl) {
+async function generateTypeLinks(nameSet, luaClasses, baseUrl, apiDumpUrl) {
   const classNames = {}
   nameSet.forEach((name) => (classNames[name] = `${baseUrl}api/${name}`))
 
@@ -247,7 +247,7 @@ async function generateTypeLinks(nameSet, luaClasses, baseUrl) {
       })
   })
 
-  const robloxTypes = await generateRobloxTypes()
+  const robloxTypes = await generateRobloxTypes(apiDumpUrl)
 
   const typeLinks = {
     ...robloxTypes, // The Roblox types go first, as they can be overwritten if the user has created their own classes and types with identical names
@@ -392,7 +392,8 @@ export default (context, options) => ({
     const typeLinksData = await generateTypeLinks(
       nameSet,
       filteredContent,
-      baseUrl
+      baseUrl,
+      options.apiDumpUrl
     )
     const typeLinks = await createData(
       "typeLinks.json",

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -17,6 +17,7 @@ Options annotated with the comment `# From Git` mean that property is automatica
 ```toml
 title = "MyProjectName"  # From Git
 gitRepoUrl = "https://github.com/evaera/moonwave" # From Git
+apiDumpUrl = "http://localhost:8080/" # Works offline
 
 gitSourceBranch = "master"
 changelog = true


### PR DESCRIPTION
Adds a `moonwave.toml` setting called `apiDumpUrl` which can be used to specify from where to grab the Roblox API dump.

If the setting is missing, the plugin defaults to the URL used currently: <https://raw.githubusercontent.com/CloneTrooper1019/Roblox-Client-Watch/roblox/API-Dump.json>

# Testing

Here is a Lune script I used to test that this feature works:

```luau
local net = require("@lune/net")
local serde = require("@lune/serde")
local stdio = require("@lune/stdio")

local ARRAY = "$array"

local function JSON_encode(value: {}): string
	local s = serde.encode("json", value)

	s = string.gsub(s, '"' .. ARRAY .. '"', "[]")

	return s
end

local handle = net.serve(8080, function()
	return JSON_encode({
		Classes = ARRAY,
		Enums = ARRAY
	})
end)

stdio.prompt("text", "Press enter to shutdown.")
handle.stop()
```

Then I added in `moonwave.toml`:

```toml
apiDumpUrl = "http://localhost:8080/"
```

Closes https://github.com/evaera/moonwave/issues/136