### PR TITLE
Keep empty lines

### DIFF
--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -379,6 +379,7 @@ impl<'a> DocEntry<'a> {
 
         let mut desc_lines = desc_lines
             .into_iter()
+            .skip_while(|line| line.is_empty())
             .map(|span| span.as_str())
             .collect::<Vec<_>>();
 

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -369,9 +369,8 @@ impl<'a> DocEntry<'a> {
         let (tag_lines, desc_lines): (Vec<Span>, Vec<Span>) = span
             .lines()
             .map(|span| {
-                let after = span.slice(3, span.len - 3);
-                if after.chars().all(char::is_whitespace) {
-                    after
+                if span.as_str() == "---" {
+                    span.slice(3, span.len - 3) // essentially becomes a newline
                 } else {
                     span.strip_prefix(indentation).unwrap_or(span)
                 }

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -65,7 +65,7 @@ struct DocEntryParseArguments<'a> {
     source: &'a DocComment,
 }
 
-fn get_within_tag<'a>(tags: &'a [Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
+fn get_within_tag(tags: &[Tag], kind_tag: &Tag) -> Result<String, Diagnostic> {
     for tag in tags {
         if let Tag::Within(within_tag) = tag {
             return Ok(within_tag.name.as_str().to_owned());

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -368,13 +368,18 @@ impl<'a> DocEntry<'a> {
 
         let (tag_lines, desc_lines): (Vec<Span>, Vec<Span>) = span
             .lines()
-            .filter(|span| span.as_str() != "---")
-            .map(|span| span.strip_prefix(indentation).unwrap_or(span))
+            .map(|span| {
+                let after = span.slice(3, span.len - 3);
+                if after.chars().all(char::is_whitespace) {
+                    after
+                } else {
+                    span.strip_prefix(indentation).unwrap_or(span)
+                }
+            })
             .partition(|line| line.starts_with(&['@', '.'][..]));
 
         let mut desc_lines = desc_lines
             .into_iter()
-            .skip_while(|line| line.is_empty())
             .map(|span| span.as_str())
             .collect::<Vec<_>>();
 

--- a/extractor/src/source_file.rs
+++ b/extractor/src/source_file.rs
@@ -63,11 +63,6 @@ impl<'a> SourceFile {
                         self.last_line = token.start_position().line();
 
                         if let Some(comment) = comment.strip_prefix('-') {
-                            if comment.trim().chars().all(|char| char == '-') {
-                                // Comment is all -------
-                                return;
-                            }
-
                             if comment.len() > 1 {
                                 if let Some(first_non_whitespace) =
                                     comment.find(|char: char| !char.is_whitespace())

--- a/extractor/test-input/passing/triple_dash.lua
+++ b/extractor/test-input/passing/triple_dash.lua
@@ -16,16 +16,16 @@
 ---	```
 ---
 ---
----	@class triple
+---	@class TripleDash
 
 --- not present in output
 --[=[
-	@class b8f83
+	@class MixedComments
 ]=]
 --- some more text
---- @type hello x
---- @within b8f83
+--- @type comment string
+--- @within MixedComments
 
---- @within triple
---- @param eher efe -- fhef
-function example(eher) end
+--- @within TripleDash
+--- @param amount number -- How many more dashes to add.
+function extra_dash(amount) end

--- a/extractor/test-input/passing/triple_dash.lua
+++ b/extractor/test-input/passing/triple_dash.lua
@@ -1,8 +1,6 @@
-----------------------------------------------------
-
----	This description starts one line down,
+---	This description
 ---			some indented text
----	And has a line in the middle, followed by trailing lines.
+---	Has a line in the middle, followed by trailing lines.
 ---
 ---	Double blank here
 ---

--- a/extractor/tests/snapshots/test_inputs__passing__triple_dash.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__triple_dash.lua-stdout.snap
@@ -8,16 +8,16 @@ expression: stdout
     "properties": [],
     "types": [
       {
-        "name": "hello",
+        "name": "comment",
         "desc": "some more text",
-        "lua_type": "x",
+        "lua_type": "string",
         "source": {
           "line": 28,
           "path": ""
         }
       }
     ],
-    "name": "b8f83",
+    "name": "MixedComments",
     "desc": "",
     "source": {
       "line": 25,
@@ -27,13 +27,13 @@ expression: stdout
   {
     "functions": [
       {
-        "name": "example",
+        "name": "extra_dash",
         "desc": "",
         "params": [
           {
-            "name": "eher",
-            "desc": "fhef",
-            "lua_type": "efe"
+            "name": "amount",
+            "desc": "How many more dashes to add.",
+            "lua_type": "number"
           }
         ],
         "returns": [],
@@ -46,7 +46,7 @@ expression: stdout
     ],
     "properties": [],
     "types": [],
-    "name": "triple",
+    "name": "TripleDash",
     "desc": "This description\n\t\tsome indented text\nHas a line in the middle, followed by trailing lines.\n\nDouble blank here\n\n```lua\nfunction test()\n\tprint(\"indentation\")\n\n\tdo\n\n\t\tprint(\"more indented\")\n\tend\nend\n```",
     "source": {
       "line": 20,

--- a/extractor/tests/snapshots/test_inputs__passing__triple_dash.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__triple_dash.lua-stdout.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/test-inputs.rs
 expression: stdout
-
 ---
 [
   {
@@ -13,7 +12,7 @@ expression: stdout
         "desc": "some more text",
         "lua_type": "x",
         "source": {
-          "line": 30,
+          "line": 28,
           "path": ""
         }
       }
@@ -21,7 +20,7 @@ expression: stdout
     "name": "b8f83",
     "desc": "",
     "source": {
-      "line": 27,
+      "line": 25,
       "path": ""
     }
   },
@@ -40,7 +39,7 @@ expression: stdout
         "returns": [],
         "function_type": "static",
         "source": {
-          "line": 33,
+          "line": 31,
           "path": ""
         }
       }
@@ -48,11 +47,10 @@ expression: stdout
     "properties": [],
     "types": [],
     "name": "triple",
-    "desc": "This description starts one line down,\n\t\tsome indented text\nAnd has a line in the middle, followed by trailing lines.\nDouble blank here\n```lua\nfunction test()\n\tprint(\"indentation\")\n\tdo\n\t\tprint(\"more indented\")\n\tend\nend\n```",
+    "desc": "This description\n\t\tsome indented text\nHas a line in the middle, followed by trailing lines.\n\nDouble blank here\n\n```lua\nfunction test()\n\tprint(\"indentation\")\n\n\tdo\n\n\t\tprint(\"more indented\")\n\tend\nend\n```",
     "source": {
-      "line": 22,
+      "line": 20,
       "path": ""
     }
   }
 ]
-


### PR DESCRIPTION
Keeps lines that are entirely dashes.

### Special case

A special case was added for "---" where it will always be a newline. I am not 100% sure if this should really be added since I think it is fair to say that even blank lines require proper indentation. Meaning, one would have to write something like this:

```luau
--- @class Car
--- 
--- A small vehicle with 4 wheels.
```

Notice the extra space on line 2.

### Test input

I changed test input a bit but I believe it is all correct now.

Commit 62c7a6cf699eec8bd8b51d380129a823e2048e3a is not really necessary and can be reverted, but I like it.

Closes https://github.com/evaera/moonwave/issues/182