### PR TITLE
Support `snake_case` for `autoSectionPath`

### DIFF
--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -340,10 +340,11 @@ export default (context, options) => ({
           if (nextDirMatch) {
             const nextDir = nextDirMatch[1]
 
-            // convert kebab-case, camelCase, PascalCase to Title Case
+            // convert kebab-case, snake_case, camelCase, PascalCase to Title Case
             const title = nextDir
               .replace(/(?<!-)([A-Z])/g, " $1")
               .replace("-", " ")
+              .replace("_", " ")
               .split(/\s+/)
               .filter((str) => str.length > 0)
               .map(capitalize)

--- a/website/docs/Configuration.md
+++ b/website/docs/Configuration.md
@@ -117,7 +117,7 @@ You can use the `autoSectionPath` option to automatically categorize classes int
 autoSectionPath = "packages"
 ```
 
-With this option set, folders inside `YOUR_REPO/packages` will be automatically used as section names. Folders may be `kebab-case`, `PascalCase`, `camelCase`, or `sentence case`: they are automatically converted to `Title Case` in the section name.
+With this option set, folders inside `YOUR_REPO/packages` will be automatically used as section names. Folders may be `kebab-case`, `snake_case`, `PascalCase`, `camelCase`, or `sentence case`: they are automatically converted to `Title Case` in the section name.
 
 For example, a class defined in `YOUR_REPO/packages/thing-doer/init.lua` will automatically be placed in a section called `Thing Doer`.
 


### PR DESCRIPTION
Converts `snake_case` to `Title Case` when using `autoSectionPath`. For example, "melee-constants" would be converted to "Melee Constants".

Closes https://github.com/evaera/moonwave/issues/183