### PR TITLE
Stop duplication of automatically sectioned classes

### DIFF
--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -354,7 +354,10 @@ export default (context, options) => ({
             )
 
             if (existingSection) {
-              existingSection.classes.push(luaClass.name)
+              // ensure not to duplicate classes
+              if (!existingSection.classes.includes(luaClass.name)) {
+                existingSection.classes.push(luaClass.name)
+              }
             } else {
               classOrder.push({
                 section: title,

--- a/docusaurus-plugin-moonwave/src/index.js
+++ b/docusaurus-plugin-moonwave/src/index.js
@@ -354,7 +354,7 @@ export default (context, options) => ({
             )
 
             if (existingSection) {
-              // ensure not to duplicate classes
+              // avoid duplicating classes
               if (!existingSection.classes.includes(luaClass.name)) {
                 existingSection.classes.push(luaClass.name)
               }


### PR DESCRIPTION
Checks whether a class was already added to a section in order to avoid duplicating it.

Closes https://github.com/evaera/moonwave/issues/179