### PR TITLE
Infer functions with explicit function type

### DIFF
--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -31,6 +31,7 @@ enum DocEntryKind {
         within: String,
         name: String,
         function_type: FunctionType,
+        function_type_conflict: bool, // whether the explicit type is different
         function_source: Option<FunctionSource>,
     },
     Property {
@@ -87,6 +88,7 @@ fn get_explicit_kind(tags: &[Tag]) -> Result<Option<DocEntryKind>, Diagnostic> {
                 return Ok(Some(DocEntryKind::Function {
                     name: function_tag.name.as_str().to_owned(),
                     function_type: function_tag.function_type.clone(),
+                    function_type_conflict: false,
                     within: get_within_tag(tags, tag)?,
                     function_source: None,
                 }));
@@ -146,10 +148,32 @@ where
     Ok(())
 }
 
-fn get_function_source(doc_comment: &DocComment, stmt: Option<&Stmt>) -> Result<Option<FunctionSource>, Diagnostic> {
+fn get_function_source(
+    doc_comment: &DocComment,
+    stmt: Option<&Stmt>,
+) -> Result<Option<(FunctionSource, FunctionType)>, Diagnostic> {
     match stmt {
-        Some(Stmt::LocalFunction(function)) => Ok(Some(function.body().clone().into())),
-        Some(Stmt::FunctionDeclaration(function)) => Ok(Some(function.body().clone().into())),
+        Some(Stmt::LocalFunction(function)) => {
+            let function_source = function.body().clone().into();
+            let function_type = FunctionType::Static;
+            let result = (function_source, function_type);
+            Ok(Some(result))
+        },
+        Some(Stmt::FunctionDeclaration(function)) => {
+            let function_body = function.body().clone().into();
+            match function.name().method_name() {
+                Some(..) => {
+                    let function_type = FunctionType::Method;
+                    let result = (function_body, function_type);
+                    Ok(Some(result))
+                }
+                None => {
+                    let function_type = FunctionType::Static;
+                    let result = (function_body, function_type);
+                    Ok(Some(result))
+                }
+            }
+        },
         Some(Stmt::LocalAssignment(assignment)) => {
             let expressions = assignment.expressions();
             let variables = assignment.names();
@@ -158,7 +182,12 @@ fn get_function_source(doc_comment: &DocComment, stmt: Option<&Stmt>) -> Result<
             assert_token_sequence_is_single(expressions, doc_comment, "expression")?;
 
             match expressions.first().unwrap().value() {
-                ast::Expression::Function(function_box) => Ok(Some((&function_box).1.clone().into())),
+                ast::Expression::Function(function_box) => {
+                    let function_body = function_box.1.clone().into();
+                    let function_type = FunctionType::Static;
+                    let result = (function_body, function_type);
+                    Ok(Some(result))
+                },
                 _ => Err(doc_comment.diagnostic("Expression must be a function")),
             }
         }
@@ -170,7 +199,12 @@ fn get_function_source(doc_comment: &DocComment, stmt: Option<&Stmt>) -> Result<
             assert_token_sequence_is_single(expressions, doc_comment, "expression")?;
 
             match expressions.into_iter().next().unwrap() {
-                ast::Expression::Function(function_box) => Ok(Some((&function_box).1.clone().into())),
+                ast::Expression::Function(function_box) => {
+                    let function_body = function_box.1.clone().into();
+                    let function_type = FunctionType::Static;
+                    let result = (function_body, function_type);
+                    Ok(Some(result))
+                },
                 _ => Err(doc_comment.diagnostic("Expression must be a function")),
             }
         }
@@ -189,19 +223,35 @@ fn determine_kind(
     let explicit_kind = get_explicit_kind(tags)?;
 
     match explicit_kind {
-        Some(DocEntryKind::Function { within, name, function_type, .. }) => {
-            let function_source = get_function_source(doc_comment, stmt)?;
+        Some(DocEntryKind::Function {
+            within,
+            name,
+            function_type: function_type_explicit,
+            ..
+        }) => {
+            let option = get_function_source(doc_comment, stmt)?;
+            if let Some((function_source, function_type_detected)) = option {
+                let d1 = std::mem::discriminant(&function_type_explicit);
+                let d2 = std::mem::discriminant(&function_type_detected);
+                let function_type_conflict = d1 != d2;
+                return Ok(DocEntryKind::Function {
+                    within,
+                    name,
+                    function_type: function_type_explicit,
+                    function_type_conflict,
+                    function_source: Some(function_source),
+                });
+            }
             return Ok(DocEntryKind::Function {
                 within,
                 name,
-                function_type,
-                function_source,
-            })
+                function_type: function_type_explicit,
+                function_type_conflict: false,
+                function_source: None,
+            });
         }
-        Some(other) => {
-            return Ok(other)
-        }
-        None => ()
+        Some(other) => return Ok(other),
+        None => (),
     }
 
     let within_tag = tags
@@ -229,6 +279,7 @@ fn determine_kind(
                 name,
                 within,
                 function_type: FunctionType::Static,
+                function_type_conflict: false,
                 function_source: Some(function.body().clone().into()),
             })
         }
@@ -244,6 +295,7 @@ fn determine_kind(
                     name: method_name.to_string(),
                     within,
                     function_type: FunctionType::Method,
+                    function_type_conflict: false,
                     function_source: Some(function.body().clone().into()),
                 })
             }
@@ -268,6 +320,7 @@ fn determine_kind(
                     name: function_name,
                     within,
                     function_type: FunctionType::Static,
+                    function_type_conflict: false,
                     function_source: Some(function.body().clone().into()),
                 })
             }
@@ -295,6 +348,7 @@ fn determine_kind(
                         name,
                         within,
                         function_type: FunctionType::Static,
+                        function_type_conflict: false,
                         function_source: Some(function_body.clone().into()),
                     })
                 }
@@ -348,6 +402,7 @@ fn determine_kind(
                         name: name.unwrap(),
                         within,
                         function_type: FunctionType::Static,
+                        function_type_conflict: false,
                         function_source: Some(function_body.clone().into()),
                     })
                 }
@@ -467,6 +522,7 @@ impl<'a> DocEntry<'a> {
                 within,
                 name,
                 function_type,
+                function_type_conflict,
                 function_source,
             } => (
                 DocEntry::Function(FunctionDocEntry::parse(
@@ -478,6 +534,7 @@ impl<'a> DocEntry<'a> {
                         source: doc_comment,
                     },
                     function_type,
+                    function_type_conflict,
                     function_source,
                 )?),
                 all_tags,

--- a/extractor/test-input/failing/explicit_function_type.lua
+++ b/extractor/test-input/failing/explicit_function_type.lua
@@ -1,0 +1,10 @@
+--- @class ECButNoS
+local E_C_But_No_S = {}
+
+-- static on method
+--- @function run_benchmark
+--- @within ECButNoS
+--- @param percentile -- Defaults to 50.
+function E_C_But_No_S:benchmark(percentile: number?): ()
+
+end

--- a/extractor/test-input/passing/explicit_function_type.lua
+++ b/extractor/test-input/passing/explicit_function_type.lua
@@ -1,0 +1,36 @@
+--- @class ECAndMaybeS
+local E_C_And_Maybe_S = {}
+
+--- @method entity_properties_async
+--- @within ECAndMaybeS
+--- @yields
+function E_C_And_Maybe_S:entity_properties_async(size: number, name: string): (number, boolean)
+
+end
+
+--- @method query
+--- @within ECAndMaybeS
+function E_C_And_Maybe_S.query(name1: string, name2: string): ()
+
+end
+
+--- @function query
+--- @within ECAndMaybeS
+function E_C_And_Maybe_S:is_component(id: number): ()
+
+end
+
+--- @method entity_simple
+--- @within ECAndMaybeS
+local function new_entity(self: E_C_And_Maybe_S): number
+	
+end
+
+-- Ensures existing behaviour is kept.
+--- @within ECAndMaybeS
+--- @param size -- The size of the entity.
+--- @param name -- The name of the entity.
+--- @return number -- How much space the entity actually takes up.
+function E_C_And_Maybe_S:entity_precise(size: number, name: string): number
+
+end

--- a/extractor/test-input/passing/explicit_function_type.lua
+++ b/extractor/test-input/passing/explicit_function_type.lua
@@ -1,36 +1,48 @@
 --- @class ECAndMaybeS
 local E_C_And_Maybe_S = {}
 
---- @method entity_properties_async
+-- [what user specifies] on [what program detects]
+-- regular = user does not specify
+
+-- static on static
+--- @function log_message
 --- @within ECAndMaybeS
---- @yields
-function E_C_And_Maybe_S:entity_properties_async(size: number, name: string): (number, boolean)
+--- @param message -- will be prefixed with "[ECAndMaybeS]: "
+function E_C_And_Maybe_S.log(message: string): ()
 
 end
 
---- @method query
+-- static on method = error
+
+-- method on static
+--- @method entity
 --- @within ECAndMaybeS
-function E_C_And_Maybe_S.query(name1: string, name2: string): ()
-
-end
-
---- @function query
---- @within ECAndMaybeS
-function E_C_And_Maybe_S:is_component(id: number): ()
-
-end
-
---- @method entity_simple
---- @within ECAndMaybeS
-local function new_entity(self: E_C_And_Maybe_S): number
+--- @param size -- size of entity in bytes
+--- @return number -- entity id
+local function world_entity(skip, size: number): number
 	
 end
 
--- Ensures existing behaviour is kept.
+-- method on method
+--- @method get_status
 --- @within ECAndMaybeS
---- @param size -- The size of the entity.
---- @param name -- The name of the entity.
---- @return number -- How much space the entity actually takes up.
-function E_C_And_Maybe_S:entity_precise(size: number, name: string): number
+--- @param entity -- entity id from [entity](ECAndMaybeS#entity)
+function E_C_And_Maybe_S:status(entity: number): ()
+
+end
+
+-- regular static
+--- @within ECAndMaybeS
+--- @param components -- whether components should be counted
+--- @return number -- total amount of entities
+function E_C_And_Maybe_S.entity_total(components: boolean): number
+
+end
+
+-- regular method
+--- @within ECAndMaybeS
+--- @param ... -- components
+--- @return ...any -- data
+function E_C_And_Maybe_S:query(...: number): ...any
 
 end

--- a/extractor/tests/snapshots/test_inputs__failing__explicit_function_type.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__explicit_function_type.lua-stderr.snap
@@ -1,0 +1,13 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+error: Can not specify a method function as a static function since the first parameter does not have a type.
+  ┌─ test-input/failing/explicit_function_type.lua:5:1
+  │  
+5 │ ╭ --- @function run_benchmark
+6 │ │ --- @within ECButNoS
+7 │ │ --- @param percentile -- Defaults to 50.
+  │ ╰────────────────────────────────────────^ Can not specify a method function as a static function since the first parameter does not have a type.
+
+error: aborting due to diagnostic error

--- a/extractor/tests/snapshots/test_inputs__failing__explicit_function_type.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__explicit_function_type.lua-stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__explicit_function_type.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__explicit_function_type.lua-stderr.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__explicit_function_type.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__explicit_function_type.lua-stdout.snap
@@ -1,0 +1,118 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+[
+  {
+    "functions": [
+      {
+        "name": "log_message",
+        "desc": "",
+        "params": [
+          {
+            "name": "message",
+            "desc": "will be prefixed with \"[ECAndMaybeS]: \"",
+            "lua_type": "string"
+          }
+        ],
+        "returns": [],
+        "function_type": "static",
+        "source": {
+          "line": 11,
+          "path": ""
+        }
+      },
+      {
+        "name": "entity",
+        "desc": "",
+        "params": [
+          {
+            "name": "size",
+            "desc": "size of entity in bytes",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "entity id",
+            "lua_type": "number"
+          }
+        ],
+        "function_type": "method",
+        "source": {
+          "line": 22,
+          "path": ""
+        }
+      },
+      {
+        "name": "get_status",
+        "desc": "",
+        "params": [
+          {
+            "name": "entity",
+            "desc": "entity id from [entity](ECAndMaybeS#entity)",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [],
+        "function_type": "method",
+        "source": {
+          "line": 30,
+          "path": ""
+        }
+      },
+      {
+        "name": "entity_total",
+        "desc": "",
+        "params": [
+          {
+            "name": "components",
+            "desc": "whether components should be counted",
+            "lua_type": "boolean"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "total amount of entities",
+            "lua_type": "number"
+          }
+        ],
+        "function_type": "static",
+        "source": {
+          "line": 38,
+          "path": ""
+        }
+      },
+      {
+        "name": "query",
+        "desc": "",
+        "params": [
+          {
+            "name": "...",
+            "desc": "components",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "data",
+            "lua_type": "...any"
+          }
+        ],
+        "function_type": "method",
+        "source": {
+          "line": 46,
+          "path": ""
+        }
+      }
+    ],
+    "properties": [],
+    "types": [],
+    "name": "ECAndMaybeS",
+    "desc": "",
+    "source": {
+      "line": 2,
+      "path": ""
+    }
+  }
+]

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -47,6 +47,11 @@ fn class_with_index() -> anyhow::Result<()> {
 }
 
 #[test]
+fn explicit_function_type() -> anyhow::Result<()> {
+    run_moonwave("passing/explicit_function_type.lua", 0)
+}
+
+#[test]
 fn external_type() -> anyhow::Result<()> {
     run_moonwave("passing/external_types.lua", 0)
 }

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -125,6 +125,11 @@ fn duplicate_names() -> anyhow::Result<()> {
     run_moonwave("failing/duplicate_names.lua", 1)
 }
 
+#[test]
+fn failing_explicit_function_type() -> anyhow::Result<()> {
+    run_moonwave("failing/explicit_function_type.lua", 1)
+}
+
 fn run_moonwave(file_name: &str, expected_status: i32) -> anyhow::Result<()> {
     let path = Path::new("test-input").join(file_name);
 


### PR DESCRIPTION
With this pull request, even if a function is annotated with `@function` or `@method`, Moonwave will still gather as much information as possible from the proceeding statement.

I did not understand everything in the issue description but I think this is everything that was intended.

### Theme

For the tests, I decided to go along with the ECS theme from the issue description. I have not used any ECSs but I have read a bit and I am pretty sure my code does not look like an ECS at all 🤣

### New field

This adds to `DocEntryKind::Function` a new field `function_type_conflict` which says whether the user specified the function as a type other than what was detected by Moonwave.

### Variant comparison

The `std::mem::discriminant` part I got from <https://stackoverflow.com/a/32554326> but I am not sure if I can use the generic function since the code falls under [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) while Moonwave is licensed under MPL 2.0, though this may fall under the [merger doctrine](https://en.wikipedia.org/wiki/Idea%E2%80%93expression_distinction#Merger_doctrine) (since this is the simplest way to compare enum variants in Rust). By the "generic function", I mean this:

```rust
fn variant_eq<T>(a: &T, b: &T) -> bool {
    std::mem::discriminant(a) == std::mem::discriminant(b)
}
```

### Better error reporting

I am not sure if it is possible to fulfill this todo, since it would involve somehow passing the `@function` span to `FunctionDocEntry::parse`: 

```rust
// TODO: Would be better to add the diagnostic on the `@function` span.
```

Closes https://github.com/evaera/moonwave/issues/157