### PR TITLE
Infer properties from assignments

### DIFF
--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -336,27 +336,32 @@ fn determine_kind(
                 }
                 _ => {
                     let lua_type = match expression {
-                        ast::Expression::InterpolatedString(_) => "string",
-                        ast::Expression::TableConstructor(table) => &table.to_string(),
-                        ast::Expression::Number(_) => "number",
-                        ast::Expression::String(_) => "string",
+                        ast::Expression::InterpolatedString(_) => Some("string".to_string()),
+                        ast::Expression::TableConstructor(table) => Some(table.to_string()),
+                        ast::Expression::Number(_) => Some("number".to_string()),
+                        ast::Expression::String(_) => Some("string".to_string()),
                         ast::Expression::Symbol(symbol) => match symbol.token().token_type() {
                             tokenizer::TokenType::Symbol { symbol } => match symbol {
-                                tokenizer::Symbol::True => "boolean",
-                                tokenizer::Symbol::False => "boolean",
-                                tokenizer::Symbol::Nil => "nil",
-                                tokenizer::Symbol::Ellipsis => return Err(doc_comment.diagnostic("Ellipsis has no type; use a `@prop` tag.")),
+                                tokenizer::Symbol::True => Some("boolean".to_string()),
+                                tokenizer::Symbol::False => Some("boolean".to_string()),
+                                tokenizer::Symbol::Nil => Some("nil".to_string()),
+                                tokenizer::Symbol::Ellipsis => None,
                                 _ => unreachable!(),
-                            }
+                            },
                             _ => unreachable!(),
-                        }
-                        _ => return Err(doc_comment.diagnostic("Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion."))
+                        },
+                        _ => None,
+                    };
+
+                    let lua_type = match lua_type {
+                        Some(lua_type) => Some(lua_type.to_owned()),
+                        None => return Err(doc_comment.diagnostic("Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion."))
                     };
 
                     Ok(DocEntryKind::Property {
                         name,
                         within,
-                        lua_type: Some(lua_type.to_owned()),
+                        lua_type,
                     })
                 }
             }

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -2,11 +2,15 @@ use serde::Serialize;
 use std::convert::TryFrom;
 
 use crate::{
-    diagnostic::{Diagnostic, Diagnostics}, doc_comment::DocComment, span::Span, tags::{validate_tags, Tag}
+    diagnostic::{Diagnostic, Diagnostics},
+    doc_comment::DocComment,
+    span::Span,
+    tags::{validate_tags, Tag},
 };
 use full_moon::{
     ast::{self, punctuated::Punctuated, Stmt},
-    node::Node, tokenizer,
+    node::Node,
+    tokenizer,
 };
 
 mod class;
@@ -277,9 +281,7 @@ fn determine_kind(
                                 brackets: _,
                                 expression: ast::Expression::String(token_reference),
                             } => Some(token_reference.token().to_string()),
-                            ast::Index::Dot { dot: _, name } => {
-                                Some(name.token().to_string())
-                            }
+                            ast::Index::Dot { dot: _, name } => Some(name.token().to_string()),
                             _ => None,
                         },
                         _ => None,
@@ -293,7 +295,7 @@ fn determine_kind(
                     "Explicitly specify a kind tag, like @function, @prop, or @class.",
                 ));
             }
-            
+
             let name = name.unwrap();
 
             match expression {
@@ -354,7 +356,7 @@ fn determine_kind(
                     Ok(DocEntryKind::Property {
                         name,
                         within,
-                        lua_type: Some(lua_type.to_owned())
+                        lua_type: Some(lua_type.to_owned()),
                     })
                 }
             }
@@ -487,7 +489,11 @@ impl<'a> DocEntry<'a> {
                 )?),
                 all_tags,
             ),
-            DocEntryKind::Property { within, name , lua_type} => (
+            DocEntryKind::Property {
+                within,
+                name,
+                lua_type,
+            } => (
                 DocEntry::Property(PropertyDocEntry::parse(
                     DocEntryParseArguments {
                         within: Some(within),
@@ -496,7 +502,7 @@ impl<'a> DocEntry<'a> {
                         tags,
                         source: doc_comment,
                     },
-                    lua_type
+                    lua_type,
                 )?),
                 all_tags,
             ),

--- a/extractor/src/doc_entry.rs
+++ b/extractor/src/doc_entry.rs
@@ -149,7 +149,12 @@ where
     Ok(())
 }
 
-fn determine_kind_assignment(name: String, within: String, expression: &ast::Expression, doc_comment: &DocComment) -> Result<DocEntryKind, Diagnostic> {
+fn determine_kind_assignment(
+    name: String,
+    within: String,
+    expression: &ast::Expression,
+    doc_comment: &DocComment,
+) -> Result<DocEntryKind, Diagnostic> {
     match expression {
         ast::Expression::Function(function_box) => {
             let function_body = &function_box.1;
@@ -343,10 +348,12 @@ fn determine_kind(
                                     expression: ast::Expression::String(string),
                                     ..
                                 } => parts.push(string.token().to_string()),
-                                ast::Index::Dot { name, .. } => parts.push(name.token().to_string()),
-                                _ => ()
-                            }
-                            _ => ()
+                                ast::Index::Dot { name, .. } => {
+                                    parts.push(name.token().to_string())
+                                }
+                                _ => (),
+                            },
+                            _ => (),
                         }
                     }
 
@@ -354,7 +361,7 @@ fn determine_kind(
                 }
                 _ => Vec::new(),
             };
-            
+
             let name = parts.pop();
 
             let within = if let Some(within) = within_tag {
@@ -362,14 +369,18 @@ fn determine_kind(
             } else if !parts.is_empty() {
                 parts.join(".")
             } else {
-                return Err(doc_comment.diagnostic("Assignment requires @within tag or a qualified name."));
+                return Err(
+                    doc_comment.diagnostic("Assignment requires @within tag or a qualified name.")
+                );
             };
 
             let name = match name {
                 Some(name) => name,
-                None => return Err(doc_comment.diagnostic(
-                    "Explicitly specify a kind tag, like @function, @prop, or @class.",
-                ))
+                None => {
+                    return Err(doc_comment.diagnostic(
+                        "Explicitly specify a kind tag, like @function, @prop, or @class.",
+                    ))
+                }
             };
 
             determine_kind_assignment(name, within, expression, doc_comment)

--- a/extractor/src/doc_entry/function.rs
+++ b/extractor/src/doc_entry/function.rs
@@ -7,7 +7,10 @@ use crate::{
     serde_util::is_false,
     tags::{CustomTag, DeprecatedTag, ErrorTag, ExternalTag, ParamTag, ReturnTag, Tag},
 };
-use full_moon::ast::{luau::TypeInfo::{self, Tuple}, FunctionBody};
+use full_moon::ast::{
+    luau::TypeInfo::{self, Tuple},
+    FunctionBody,
+};
 use serde::Serialize;
 
 use super::DocEntryParseArguments;
@@ -86,7 +89,11 @@ impl TryFrom<&TypeInfo> for FunctionSource {
     type Error = usize;
     fn try_from(type_info: &TypeInfo) -> Result<Self, usize> {
         match type_info {
-            TypeInfo::Callback { arguments, return_type, .. } => {
+            TypeInfo::Callback {
+                arguments,
+                return_type,
+                ..
+            } => {
                 let mut params = Vec::new();
 
                 for (index, argument) in arguments.iter().enumerate() {
@@ -102,9 +109,9 @@ impl TryFrom<&TypeInfo> for FunctionSource {
 
                 let returns = get_return_types(&return_type);
 
-                Ok(FunctionSource {params, returns })
-            },
-            _ => unreachable!()
+                Ok(FunctionSource { params, returns })
+            }
+            _ => unreachable!(),
         }
     }
 }

--- a/extractor/src/doc_entry/function.rs
+++ b/extractor/src/doc_entry/function.rs
@@ -7,7 +7,7 @@ use crate::{
     serde_util::is_false,
     tags::{CustomTag, DeprecatedTag, ErrorTag, ExternalTag, ParamTag, ReturnTag, Tag},
 };
-use full_moon::ast::{luau::TypeInfo::Tuple, FunctionBody};
+use full_moon::ast::{luau::TypeInfo::{self, Tuple}, FunctionBody};
 use serde::Serialize;
 
 use super::DocEntryParseArguments;
@@ -24,6 +24,22 @@ pub enum FunctionType {
 pub struct FunctionSource {
     params: Vec<FunctionParam>,
     returns: Vec<FunctionReturn>,
+}
+
+fn get_return_types(info: &TypeInfo) -> Vec<FunctionReturn> {
+    match info {
+        Tuple { types, .. } => types
+            .into_iter()
+            .map(|ty| FunctionReturn {
+                lua_type: ty.to_string(),
+                desc: String::new(),
+            })
+            .collect::<Vec<_>>(),
+        _ => vec![FunctionReturn {
+            lua_type: info.to_string(),
+            desc: String::new(),
+        }],
+    }
 }
 
 impl From<FunctionBody> for FunctionSource {
@@ -58,27 +74,38 @@ impl From<FunctionBody> for FunctionSource {
         }
 
         let returns = match func.return_type() {
-            Some(return_type) => {
-                let info = return_type.type_info();
-
-                match info {
-                    Tuple { types, .. } => types
-                        .into_iter()
-                        .map(|ty| FunctionReturn {
-                            lua_type: ty.to_string(),
-                            desc: String::new(),
-                        })
-                        .collect::<Vec<_>>(),
-                    _ => vec![FunctionReturn {
-                        lua_type: info.to_string(),
-                        desc: String::new(),
-                    }],
-                }
-            }
+            Some(return_type) => get_return_types(return_type.type_info()),
             None => Vec::new(),
         };
 
         FunctionSource { params, returns }
+    }
+}
+
+impl TryFrom<&TypeInfo> for FunctionSource {
+    type Error = usize;
+    fn try_from(type_info: &TypeInfo) -> Result<Self, usize> {
+        match type_info {
+            TypeInfo::Callback { arguments, return_type, .. } => {
+                let mut params = Vec::new();
+
+                for (index, argument) in arguments.iter().enumerate() {
+                    params.push(FunctionParam {
+                        name: match argument.name() {
+                            Some((name, ..)) => name.to_string(),
+                            None => return Err(index),
+                        },
+                        desc: "".to_string(),
+                        lua_type: argument.type_info().to_string(),
+                    });
+                }
+
+                let returns = get_return_types(&return_type);
+
+                Ok(FunctionSource {params, returns })
+            },
+            _ => unreachable!()
+        }
     }
 }
 

--- a/extractor/src/doc_entry/function.rs
+++ b/extractor/src/doc_entry/function.rs
@@ -107,7 +107,7 @@ impl TryFrom<&TypeInfo> for FunctionSource {
                     });
                 }
 
-                let returns = get_return_types(&return_type);
+                let returns = get_return_types(return_type);
 
                 Ok(FunctionSource { params, returns })
             }

--- a/extractor/src/doc_entry/property.rs
+++ b/extractor/src/doc_entry/property.rs
@@ -47,7 +47,7 @@ pub struct PropertyDocEntry<'a> {
 }
 
 impl<'a> PropertyDocEntry<'a> {
-    pub(super) fn parse(args: DocEntryParseArguments<'a>) -> Result<Self, Diagnostics> {
+    pub(super) fn parse(args: DocEntryParseArguments<'a>, lua_type: Option<String>) -> Result<Self, Diagnostics> {
         let DocEntryParseArguments {
             name,
             desc,
@@ -60,7 +60,7 @@ impl<'a> PropertyDocEntry<'a> {
             name,
             desc,
             source,
-            lua_type: String::new(),
+            lua_type: lua_type.unwrap_or_else(String::new),
             since: None,
             deprecated: None,
             within: within.unwrap(),

--- a/extractor/src/doc_entry/property.rs
+++ b/extractor/src/doc_entry/property.rs
@@ -63,7 +63,7 @@ impl<'a> PropertyDocEntry<'a> {
             name,
             desc,
             source,
-            lua_type: lua_type.unwrap_or_else(String::new),
+            lua_type: lua_type.unwrap_or_default(),
             since: None,
             deprecated: None,
             within: within.unwrap(),

--- a/extractor/src/doc_entry/property.rs
+++ b/extractor/src/doc_entry/property.rs
@@ -47,7 +47,10 @@ pub struct PropertyDocEntry<'a> {
 }
 
 impl<'a> PropertyDocEntry<'a> {
-    pub(super) fn parse(args: DocEntryParseArguments<'a>, lua_type: Option<String>) -> Result<Self, Diagnostics> {
+    pub(super) fn parse(
+        args: DocEntryParseArguments<'a>,
+        lua_type: Option<String>,
+    ) -> Result<Self, Diagnostics> {
         let DocEntryParseArguments {
             name,
             desc,

--- a/extractor/test-input/failing/infer_assignment.lua
+++ b/extractor/test-input/failing/infer_assignment.lua
@@ -20,7 +20,7 @@ InferAssignment.null = string.char(0)
 
 -- IfExpression
 --- @within InferAssignment
-InferAssignment.uh_oh = InferAssignment.book1984 == 5
+InferAssignment.uh_oh = if InferAssignment.book1984 == 5 then "gg" else "yippee!"
 
 -- Symbol > Ellipsis
 -- `...` is populated with program arguments in the demo Luau runtime.

--- a/extractor/test-input/failing/infer_assignment.lua
+++ b/extractor/test-input/failing/infer_assignment.lua
@@ -1,36 +1,28 @@
 --- @class InferAssignment
 local InferAssignment = {}
 
--- BinaryOperator
---- @within InferAssignment
+--- BinaryOperator
 InferAssignment.book1984 = 2 + 2
 
--- Parentheses
---- @within InferAssignment
+--- Parentheses
 --- Get it? Inside is an em dash, which can also be used for parenthetical clauses. A parenthetical symbol surrounded by parentheses 😹
 InferAssignment.parenthetical = ("—")
 
--- UnaryOperator
---- @within InferAssignment
+--- UnaryOperator
 InferAssignment.book4891 = -InferAssignment.book1984
 
--- FunctionCall
---- @within InferAssignment
+--- FunctionCall
 InferAssignment.null = string.char(0)
 
--- IfExpression
---- @within InferAssignment
+--- IfExpression
 InferAssignment.uh_oh = if InferAssignment.book1984 == 5 then "gg" else "yippee!"
 
--- Symbol > Ellipsis
--- `...` is populated with program arguments in the demo Luau runtime.
---- @within InferAssignment
+--- Symbol > Ellipsis
+--- `...` is populated with program arguments in the demo Luau runtime.
 InferAssignment.program_argument = ...
 
--- TypeAssertion > Callback + missing parameter name
---- @within InferAssignment
+--- TypeAssertion > Callback + missing parameter name
 InferAssignment.get_book_name_by_id = nil :: (number) -> string
 
--- Var
---- @within InferAssignment
+--- Var
 InferAssignment.uh_oh_part_2 = math.sqrt(-1)

--- a/extractor/test-input/failing/infer_assignment.lua
+++ b/extractor/test-input/failing/infer_assignment.lua
@@ -1,0 +1,36 @@
+--- @class InferAssignment
+local InferAssignment = {}
+
+-- BinaryOperator
+--- @within InferAssignment
+InferAssignment.book1984 = 2 + 2
+
+-- Parentheses
+--- @within InferAssignment
+--- Get it? Inside is an em dash, which can also be used for parenthetical clauses. A parenthetical symbol surrounded by parentheses 😹
+InferAssignment.parenthetical = ("—")
+
+-- UnaryOperator
+--- @within InferAssignment
+InferAssignment.book4891 = -InferAssignment.book1984
+
+-- FunctionCall
+--- @within InferAssignment
+InferAssignment.null = string.char(0)
+
+-- IfExpression
+--- @within InferAssignment
+InferAssignment.uh_oh = InferAssignment.book1984 == 5
+
+-- Symbol > Ellipsis
+-- `...` is populated with program arguments in the demo Luau runtime.
+--- @within InferAssignment
+InferAssignment.program_argument = ...
+
+-- TypeAssertion > Callback + missing parameter name
+--- @within InferAssignment
+InferAssignment.get_book_name_by_id = nil :: (number) -> string
+
+-- Var
+--- @within InferAssignment
+InferAssignment.uh_oh_part_2 = math.sqrt(-1)

--- a/extractor/test-input/passing/infer_assignment.lua
+++ b/extractor/test-input/passing/infer_assignment.lua
@@ -1,0 +1,52 @@
+--- @class InferAssignment
+local InferAssignment = {}
+
+-- TableConstructor
+--- @within InferAssignment
+InferAssignment.world = {
+	gravity = 9.8,
+	time = "relative"
+}
+
+-- Number
+--- @within InferAssignment
+InferAssignment.year = 2025
+
+-- InterpolatedString
+--- @within InferAssignment
+InferAssignment.copyright = `Copyright (c) {InferAssignment.year}`
+
+-- Function
+--- @within InferAssignment
+InferAssignment.on_year_change = function(year: number): ()
+	InferAssignment.year = year
+	InferAssignment.copyright = `Copyright (c) {InferAssignment.year}`
+end
+
+-- String
+--- @within InferAssignment
+InferAssignment.name = "InferAssignment"
+
+-- Symbol > True
+--- @within InferAssignment
+InferAssignment.enabled = true
+
+-- Symbol > False
+--- @within InferAssignment
+InferAssignment.DEBUG = false
+
+-- Symbol > Nil
+--- @within InferAssignment
+InferAssignment.currently_spectating = nil
+
+-- TypeAssertion > Callback + parameter name
+--- @within InferAssignment
+--- @return boolean -- whether it was successful
+--- @yields
+InferAssignment.announce_message_async = nil :: (message: string) -> boolean
+
+-- TypeAssertion > string
+--- @within InferAssignment
+InferAssignment.version = nil :: string
+
+-- Other TypeAssertion variants could be added but they all (hopefully) follow the exact same logic.

--- a/extractor/test-input/passing/infer_assignment.lua
+++ b/extractor/test-input/passing/infer_assignment.lua
@@ -1,52 +1,42 @@
 --- @class InferAssignment
 local InferAssignment = {}
 
--- TableConstructor
---- @within InferAssignment
+--- TableConstructor
 InferAssignment.world = {
 	gravity = 9.8,
 	time = "relative"
 }
 
--- Number
---- @within InferAssignment
+--- Number
 InferAssignment.year = 2025
 
--- InterpolatedString
---- @within InferAssignment
+--- InterpolatedString
 InferAssignment.copyright = `Copyright (c) {InferAssignment.year}`
 
--- Function
---- @within InferAssignment
+--- Function
 InferAssignment.on_year_change = function(year: number): ()
 	InferAssignment.year = year
 	InferAssignment.copyright = `Copyright (c) {InferAssignment.year}`
 end
 
--- String
---- @within InferAssignment
+--- String
 InferAssignment.name = "InferAssignment"
 
--- Symbol > True
---- @within InferAssignment
+--- Symbol > True
 InferAssignment.enabled = true
 
--- Symbol > False
---- @within InferAssignment
+--- Symbol > False
 InferAssignment.DEBUG = false
 
--- Symbol > Nil
---- @within InferAssignment
+--- Symbol > Nil
 InferAssignment.currently_spectating = nil
 
--- TypeAssertion > Callback + parameter name
---- @within InferAssignment
+--- TypeAssertion > Callback + parameter name
 --- @return boolean -- whether it was successful
 --- @yields
 InferAssignment.announce_message_async = nil :: (message: string) -> boolean
 
--- TypeAssertion > string
---- @within InferAssignment
+--- TypeAssertion > string
 InferAssignment.version = nil :: string
 
 -- Other TypeAssertion variants could be added but they all (hopefully) follow the exact same logic.

--- a/extractor/test-input/passing/infer_assignment.lua
+++ b/extractor/test-input/passing/infer_assignment.lua
@@ -40,3 +40,8 @@ InferAssignment.announce_message_async = nil :: (message: string) -> boolean
 InferAssignment.version = nil :: string
 
 -- Other TypeAssertion variants could be added but they all (hopefully) follow the exact same logic.
+
+--- @within InferAssignment
+local timestamp = 1753211834
+
+-- Other local assignment values would be added but they all (hopefully) follow the exact same logic.

--- a/extractor/test-input/passing/infer_assignment.lua
+++ b/extractor/test-input/passing/infer_assignment.lua
@@ -45,3 +45,9 @@ InferAssignment.version = nil :: string
 local timestamp = 1753211834
 
 -- Other local assignment values would be added but they all (hopefully) follow the exact same logic.
+
+--- @class InferAssignment.upcoming
+InferAssignment.upcoming = {}
+
+--- This will be a Crazy update.
+InferAssignment.upcoming.version = "1.0.0"

--- a/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
@@ -1,0 +1,54 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+  ┌─ test-input/failing/infer_assignment.lua:5:1
+  │
+5 │ --- @within InferAssignment
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:9:1
+   │  
+ 9 │ ╭ --- @within InferAssignment
+10 │ │ --- Get it? Inside is an em dash, which can also be used for parenthetical clauses. A parenthetical symbol surrounded by parentheses 😹
+   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:14:1
+   │
+14 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:18:1
+   │
+18 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:22:1
+   │
+22 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Ellipsis has no type; use a `@prop` tag.
+   ┌─ test-input/failing/infer_assignment.lua:27:1
+   │
+27 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ellipsis has no type; use a `@prop` tag.
+
+error: Type assertion must contain names for all parameters; type #1 is missing a name.
+   ┌─ test-input/failing/infer_assignment.lua:31:1
+   │
+31 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Type assertion must contain names for all parameters; type #1 is missing a name.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:35:1
+   │
+35 │ --- @within InferAssignment
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: aborting due to diagnostic error

--- a/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
@@ -3,52 +3,53 @@ source: tests/test-inputs.rs
 expression: stderr
 ---
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-  ┌─ test-input/failing/infer_assignment.lua:5:1
+  ┌─ test-input/failing/infer_assignment.lua:4:1
   │
-5 │ --- @within InferAssignment
-  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+4 │ --- BinaryOperator
+  │ ^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-   ┌─ test-input/failing/infer_assignment.lua:9:1
-   │  
- 9 │ ╭ --- @within InferAssignment
-10 │ │ --- Get it? Inside is an em dash, which can also be used for parenthetical clauses. A parenthetical symbol surrounded by parentheses 😹
-   │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+  ┌─ test-input/failing/infer_assignment.lua:7:1
+  │  
+7 │ ╭ --- Parentheses
+8 │ │ --- Get it? Inside is an em dash, which can also be used for parenthetical clauses. A parenthetical symbol surrounded by parentheses 😹
+  │ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+   ┌─ test-input/failing/infer_assignment.lua:11:1
+   │
+11 │ --- UnaryOperator
+   │ ^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
    ┌─ test-input/failing/infer_assignment.lua:14:1
    │
-14 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+14 │ --- FunctionCall
+   │ ^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-   ┌─ test-input/failing/infer_assignment.lua:18:1
+   ┌─ test-input/failing/infer_assignment.lua:17:1
    │
-18 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+17 │ --- IfExpression
+   │ ^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-   ┌─ test-input/failing/infer_assignment.lua:22:1
+   ┌─ test-input/failing/infer_assignment.lua:20:1
+   │  
+20 │ ╭ --- Symbol > Ellipsis
+21 │ │ --- `...` is populated with program arguments in the demo Luau runtime.
+   │ ╰───────────────────────────────────────────────────────────────────────^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+
+error: Type assertion must contain names for all parameters; type #1 is missing a name.
+   ┌─ test-input/failing/infer_assignment.lua:24:1
    │
-22 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+24 │ --- TypeAssertion > Callback + missing parameter name
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Type assertion must contain names for all parameters; type #1 is missing a name.
 
 error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
    ┌─ test-input/failing/infer_assignment.lua:27:1
    │
-27 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-
-error: Type assertion must contain names for all parameters; type #1 is missing a name.
-   ┌─ test-input/failing/infer_assignment.lua:31:1
-   │
-31 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Type assertion must contain names for all parameters; type #1 is missing a name.
-
-error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
-   ┌─ test-input/failing/infer_assignment.lua:35:1
-   │
-35 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
+27 │ --- Var
+   │ ^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: aborting due to diagnostic error

--- a/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stderr.snap
@@ -33,11 +33,11 @@ error: Expression must be a function, a string, a table, a number, `true`, `fals
 22 │ --- @within InferAssignment
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
-error: Ellipsis has no type; use a `@prop` tag.
+error: Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
    ┌─ test-input/failing/infer_assignment.lua:27:1
    │
 27 │ --- @within InferAssignment
-   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Ellipsis has no type; use a `@prop` tag.
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Expression must be a function, a string, a table, a number, `true`, `false`, `nil`, or a type assertion.
 
 error: Type assertion must contain names for all parameters; type #1 is missing a name.
    ┌─ test-input/failing/infer_assignment.lua:31:1

--- a/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__failing__infer_assignment.lua-stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stderr.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stderr.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test-inputs.rs
+expression: stderr
+---
+

--- a/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
@@ -136,5 +136,26 @@ expression: stdout
       "line": 2,
       "path": ""
     }
+  },
+  {
+    "functions": [],
+    "properties": [
+      {
+        "name": "version",
+        "desc": "This will be a Crazy update.",
+        "lua_type": "string",
+        "source": {
+          "line": 53,
+          "path": ""
+        }
+      }
+    ],
+    "types": [],
+    "name": "InferAssignment.upcoming",
+    "desc": "",
+    "source": {
+      "line": 50,
+      "path": ""
+    }
   }
 ]

--- a/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
@@ -7,7 +7,7 @@ expression: stdout
     "functions": [
       {
         "name": "on_year_change",
-        "desc": "",
+        "desc": "Function",
         "params": [
           {
             "name": "year",
@@ -18,13 +18,13 @@ expression: stdout
         "returns": [],
         "function_type": "static",
         "source": {
-          "line": 21,
+          "line": 17,
           "path": ""
         }
       },
       {
         "name": "announce_message_async",
-        "desc": "",
+        "desc": "TypeAssertion > Callback + parameter name",
         "params": [
           {
             "name": "message",
@@ -41,7 +41,7 @@ expression: stdout
         "function_type": "static",
         "yields": true,
         "source": {
-          "line": 46,
+          "line": 37,
           "path": ""
         }
       }
@@ -49,73 +49,73 @@ expression: stdout
     "properties": [
       {
         "name": "world",
-        "desc": "",
+        "desc": "TableConstructor",
         "lua_type": "{\n\tgravity = 9.8,\n\ttime = \"relative\"\n}\n",
         "source": {
-          "line": 6,
+          "line": 5,
           "path": ""
         }
       },
       {
         "name": "year",
-        "desc": "",
+        "desc": "Number",
         "lua_type": "number",
         "source": {
-          "line": 13,
+          "line": 11,
           "path": ""
         }
       },
       {
         "name": "copyright",
-        "desc": "",
+        "desc": "InterpolatedString",
         "lua_type": "string",
         "source": {
-          "line": 17,
+          "line": 14,
           "path": ""
         }
       },
       {
         "name": "name",
-        "desc": "",
+        "desc": "String",
         "lua_type": "string",
         "source": {
-          "line": 28,
+          "line": 23,
           "path": ""
         }
       },
       {
         "name": "enabled",
-        "desc": "",
+        "desc": "Symbol > True",
         "lua_type": "boolean",
+        "source": {
+          "line": 26,
+          "path": ""
+        }
+      },
+      {
+        "name": "DEBUG",
+        "desc": "Symbol > False",
+        "lua_type": "boolean",
+        "source": {
+          "line": 29,
+          "path": ""
+        }
+      },
+      {
+        "name": "currently_spectating",
+        "desc": "Symbol > Nil",
+        "lua_type": "nil",
         "source": {
           "line": 32,
           "path": ""
         }
       },
       {
-        "name": "DEBUG",
-        "desc": "",
-        "lua_type": "boolean",
-        "source": {
-          "line": 36,
-          "path": ""
-        }
-      },
-      {
-        "name": "currently_spectating",
-        "desc": "",
-        "lua_type": "nil",
-        "source": {
-          "line": 40,
-          "path": ""
-        }
-      },
-      {
         "name": "version",
-        "desc": "",
+        "desc": "TypeAssertion > string",
         "lua_type": "string\n",
         "source": {
-          "line": 50,
+          "line": 40,
           "path": ""
         }
       }

--- a/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
@@ -1,0 +1,131 @@
+---
+source: tests/test-inputs.rs
+expression: stdout
+---
+[
+  {
+    "functions": [
+      {
+        "name": "on_year_change",
+        "desc": "",
+        "params": [
+          {
+            "name": "year",
+            "desc": "",
+            "lua_type": "number"
+          }
+        ],
+        "returns": [],
+        "function_type": "static",
+        "source": {
+          "line": 21,
+          "path": ""
+        }
+      },
+      {
+        "name": "announce_message_async",
+        "desc": "",
+        "params": [
+          {
+            "name": "message",
+            "desc": "",
+            "lua_type": "string"
+          }
+        ],
+        "returns": [
+          {
+            "desc": "whether it was successful",
+            "lua_type": "boolean"
+          }
+        ],
+        "function_type": "static",
+        "yields": true,
+        "source": {
+          "line": 46,
+          "path": ""
+        }
+      }
+    ],
+    "properties": [
+      {
+        "name": "world",
+        "desc": "",
+        "lua_type": "{\n\tgravity = 9.8,\n\ttime = \"relative\"\n}\n",
+        "source": {
+          "line": 6,
+          "path": ""
+        }
+      },
+      {
+        "name": "year",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 13,
+          "path": ""
+        }
+      },
+      {
+        "name": "copyright",
+        "desc": "",
+        "lua_type": "string",
+        "source": {
+          "line": 17,
+          "path": ""
+        }
+      },
+      {
+        "name": "name",
+        "desc": "",
+        "lua_type": "string",
+        "source": {
+          "line": 28,
+          "path": ""
+        }
+      },
+      {
+        "name": "enabled",
+        "desc": "",
+        "lua_type": "boolean",
+        "source": {
+          "line": 32,
+          "path": ""
+        }
+      },
+      {
+        "name": "DEBUG",
+        "desc": "",
+        "lua_type": "boolean",
+        "source": {
+          "line": 36,
+          "path": ""
+        }
+      },
+      {
+        "name": "currently_spectating",
+        "desc": "",
+        "lua_type": "nil",
+        "source": {
+          "line": 40,
+          "path": ""
+        }
+      },
+      {
+        "name": "version",
+        "desc": "",
+        "lua_type": "string\n",
+        "source": {
+          "line": 50,
+          "path": ""
+        }
+      }
+    ],
+    "types": [],
+    "name": "InferAssignment",
+    "desc": "",
+    "source": {
+      "line": 2,
+      "path": ""
+    }
+  }
+]

--- a/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
+++ b/extractor/tests/snapshots/test_inputs__passing__infer_assignment.lua-stdout.snap
@@ -118,6 +118,15 @@ expression: stdout
           "line": 40,
           "path": ""
         }
+      },
+      {
+        "name": "timestamp",
+        "desc": "",
+        "lua_type": "number",
+        "source": {
+          "line": 45,
+          "path": ""
+        }
       }
     ],
     "types": [],

--- a/extractor/tests/test-inputs.rs
+++ b/extractor/tests/test-inputs.rs
@@ -27,6 +27,11 @@ fn indentation() -> anyhow::Result<()> {
 }
 
 #[test]
+fn infer_assignment() -> anyhow::Result<()> {
+    run_moonwave("passing/infer_assignment.lua", 0)
+}
+
+#[test]
 fn triple_dash() -> anyhow::Result<()> {
     run_moonwave("passing/triple_dash.lua", 0)
 }
@@ -103,6 +108,11 @@ fn missing_starting_newline() -> anyhow::Result<()> {
 #[test]
 fn failing_function_no_within() -> anyhow::Result<()> {
     run_moonwave("failing/function_no_within.lua", 1)
+}
+
+#[test]
+fn failing_infer_assignment() -> anyhow::Result<()> {
+    run_moonwave("failing/infer_assignment.lua", 1)
 }
 
 #[test]


### PR DESCRIPTION
Infers properties from assignment statements. Both `within` and `name` are inferred. For example, this is now possible:

```luau
--- @class MyClass
local MyClass = {

--- Follows [Semantic Versioning](https://semver.org/).
MyClass.version = "0.1.0"
```

This also works with local assignments, though `within` must be specified.

### Symbol

I tried looking for what a symbol can be in an expression and the only answer I found was this code in Full Moon:

https://github.com/Kampfkarren/full-moon/blob/aeb4d4bcf9ed491ed2139dc3cab61f90b77532f1/full-moon/src/ast/parsers.rs#L1671

### Website

Not sure where to write about this on the website.

Could go here: https://eryn.io/moonwave/docs/TagList/#prop

But functions are also supported...

### Snapshots

For your information Cargo Insta updated the snapshot format.

```
Snapshot test passes but the existing value is in a legacy format. Please run `cargo insta test --force-update-snapshots` to update to a newer format.
```

### Tables

Tables do not work too well since they just get `to_string`ed. Perhaps the program should recurse through the table to use the type for each field?

### Clippy

Clippy made some good points about using `if let` instead of a `match` statement but I think that, since it is dealing with Full Moon stuff it is probably best to leave it as `match`.

### Var

The GitHub issue seems to suggest to include `Expression::Var`, but this does not really make sense to me since Moonwave does not know the variable's type. I guess it could just show the name of the variable?

### Qualified names

I made the last part of the whole name be used as `name` of the doc entry. This matches `FunctionDeclaration`:

```rust
let function_name = names.pop().unwrap().to_string(); 
```

But this contrasts with my other pull request: https://github.com/evaera/moonwave/pull/176

I still think it makes more sense to use the first part as `within`, which aligns with that pull request. However, I added a test that asserts the behaviour that currently exists in this pull request, just so that the behaviour is defined.

### TypeInfo to String

I think this pull request could benefit from the `type_info_to_string` function from my very first pull request: https://github.com/evaera/moonwave/pull/164

It might even be good to use it in every case that `TypeInfo::to_string` is used.

Closes https://github.com/evaera/moonwave/issues/169